### PR TITLE
Bugfix/await reconciliation

### DIFF
--- a/lib/lease-manager.js
+++ b/lib/lease-manager.js
@@ -226,7 +226,7 @@ class LeaseManager {
       const changesDetected = (await Object.keys(shards).reduce(async (result, id) => {
         return (await result).concat(await acquireLease(this, id, shards));
       }, [])).some(Boolean);
-      if (changesDetected) consumersManager.reconcile();
+      if (changesDetected) await consumersManager.reconcile();
 
       privateProps.timeoutId = setTimeout(acquireLeases, ACQUIRE_LEASES_INTERVAL);
     };

--- a/package.json
+++ b/package.json
@@ -14,8 +14,9 @@
     "lifion"
   ],
   "author": "Edgardo Avilés <Edgardo.Aviles@ADP.com>",
-  "maintainers": [
-    "Mackenzie Turner <turner.mackenzie.m@gmail.com>"
+  "contributors": [
+    "Mackenzie Turner <turner.mackenzie.m@gmail.com>",
+    "Simon Gellis <Simon.Gellis@ADP.com>"
   ],
   "license": "MIT",
   "main": "lib/index.js",


### PR DESCRIPTION
When calling `startConsumer()`, the module isn't waiting to reconcile consumers on newly-leased shards.