### PR TITLE
Fixing back-pressure example

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,19 +30,23 @@ kinesis.startConsumer();
 To take advantage of back-pressure, the client can be piped to a writable stream:
 
 ```js
+const util = require('util');
 const Kinesis = require('lifion-kinesis');
-const { pipeline } = require('stream');
+const stream = require('stream');
 
-pipeline([
-  new Kinesis(/* options */),
-  new Writable({
+const pipeline = util.promisify(stream.pipeline);
+const kinesis = new Kinesis(/* options */),
+pipeline(
+  kinesis,
+  new stream.Writable({
     objectMode: true,
     write(data, encoding, callback) {
       console.log(data);
       callback();
     }
   })
-]);
+).catch(console.error);
+kinesis.startConsumer();
 ```
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -30,13 +30,17 @@ kinesis.startConsumer();
 To take advantage of back-pressure, the client can be piped to a writable stream:
 
 ```js
-const util = require('util');
+const { promisify } = require('util');
 const Kinesis = require('lifion-kinesis');
 const stream = require('stream');
 
-const pipeline = util.promisify(stream.pipeline);
-const kinesis = new Kinesis(/* options */),
-pipeline(
+const asyncPipeline = promisify(stream.pipeline);
+const kinesis = new Kinesis({
+  streamName: 'sample-stream'
+  /* other options from AWS.Kinesis */
+});
+
+asyncPipeline(
   kinesis,
   new stream.Writable({
     objectMode: true,

--- a/templates/README.hbs
+++ b/templates/README.hbs
@@ -30,19 +30,23 @@ kinesis.startConsumer();
 To take advantage of back-pressure, the client can be piped to a writable stream:
 
 ```js
+const util = require('util');
 const Kinesis = require('lifion-kinesis');
-const { pipeline } = require('stream');
+const stream = require('stream');
 
-pipeline([
-  new Kinesis(/* options */),
-  new Writable({
+const pipeline = util.promisify(stream.pipeline);
+const kinesis = new Kinesis(/* options */),
+pipeline(
+  kinesis,
+  new stream.Writable({
     objectMode: true,
     write(data, encoding, callback) {
       console.log(data);
       callback();
     }
   })
-]);
+).catch(console.error);
+kinesis.startConsumer();
 ```
 
 ## Features

--- a/templates/README.hbs
+++ b/templates/README.hbs
@@ -30,13 +30,17 @@ kinesis.startConsumer();
 To take advantage of back-pressure, the client can be piped to a writable stream:
 
 ```js
-const util = require('util');
+const { promisify } = require('util');
 const Kinesis = require('lifion-kinesis');
 const stream = require('stream');
 
-const pipeline = util.promisify(stream.pipeline);
-const kinesis = new Kinesis(/* options */),
-pipeline(
+const asyncPipeline = promisify(stream.pipeline);
+const kinesis = new Kinesis({
+  streamName: 'sample-stream'
+  /* other options from AWS.Kinesis */
+});
+
+asyncPipeline(
   kinesis,
   new stream.Writable({
     objectMode: true,


### PR DESCRIPTION
The documentation seems to be outdated for the back-pressure example.
This is the current implementation I'm using on my side to make it work for Node 14.
For Node 16, `require('stream/promises')` might be a better fit.