### PR TITLE
chore: modernize CI and drop shared Lifion tooling

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,22 +1,37 @@
 version: 2
 updates:
-- package-ecosystem: github-actions
-  directory: "/"
-  schedule:
-    interval: weekly
-    day: tuesday
-  open-pull-requests-limit: 10
-  assignees:
-    - "jennyEckstein"
-    - "eaviles"
-    - "BizzlePop34"
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: weekly
-    day: tuesday
-  open-pull-requests-limit: 10
-  assignees:
-    - "jennyEckstein"
-    - "eaviles"
-    - "BizzlePop34"
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: tuesday
+    open-pull-requests-limit: 10
+    assignees:
+      - "jennyEckstein"
+      - "eaviles"
+      - "BizzlePop34"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: tuesday
+    open-pull-requests-limit: 10
+    assignees:
+      - "jennyEckstein"
+      - "eaviles"
+      - "BizzlePop34"
+    groups:
+      dev-dependencies:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+      production-dependencies:
+        dependency-type: production
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,52 +2,28 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [develop, master]
+    branches: [develop, main]
   pull_request:
-    # The branches below must be a subset of the branches above
     branches: [develop]
   schedule:
     - cron: '0 14 * * 0'
 
 jobs:
-  analyse:
-    name: Analyse
+  analyze:
+    name: Analyze
     runs-on: ubuntu-latest
-
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
-      with:
-        # We must fetch at least the immediate parents so that if this is
-        # a pull request then we can checkout the head.
-        fetch-depth: 2
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-    # If this run was triggered by a pull request event, then checkout
-    # the head of the pull request instead of the merge commit.
-    - run: git checkout HEAD^2
-      if: ${{ github.event_name == 'pull_request' }}
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
-      with:
-        languages: javascript
-
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
-
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
-
-    #- run: |
-    #   make bootstrap
-    #   make release
-
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3

--- a/.github/workflows/publish-module.yml
+++ b/.github/workflows/publish-module.yml
@@ -9,12 +9,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           check-latest: true
-          node-version: '12'
+          node-version: '20'
       - name: Install
         run: npm ci --loglevel=error
         env:
@@ -31,12 +31,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           check-latest: true
-          node-version: '12'
+          node-version: '20'
           registry-url: 'https://registry.npmjs.org'
       - name: Install
         run: npm ci --loglevel=error

--- a/.github/workflows/pull-request-check.yml
+++ b/.github/workflows/pull-request-check.yml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [12, 14, 16]
+        node-version: [20, 22, 24]
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           check-latest: true
@@ -33,6 +33,6 @@ jobs:
         env:
           CI: true
       - name: Report coverage
-        run: npx codecov
-        env:
-          CODECOV_TOKEN: ${{secrets.CODECOV_TOKEN}}
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -87,10 +87,5 @@
         "lib"
       ]
     }
-  },
-  "@lifion/core-commons": {
-    "template": "public",
-    "updated": "2019-11-11T23:13:26.785Z",
-    "version": "2.3.4"
   }
 }


### PR DESCRIPTION
First step of the modernization effort tracked in #727. No library code changes; this is all CI and tooling.

## What changed

- **Node in CI**: test matrix is now Node 20/22/24 (12/14/16 are EOL). The publish workflow builds on Node 20 instead of 12.
- **GitHub Actions bumped**: `checkout` v2→v4, `setup-node` v2→v4, CodeQL action v1→v3. The CodeQL workflow is simplified to the current minimal JavaScript template (drops the legacy PR-checkout dance and the unused autobuild step, adds explicit `permissions`), and its push trigger is fixed from the non-existent `master` to `main`.
- **Coverage upload**: replaced the sunset `npx codecov` bash uploader with `codecov/codecov-action@v4`.
- **Dependabot**: grouped dev and prod minor/patch updates to cut PR noise. Major bumps still arrive as individual PRs.
- **Decoupling**: removed the `@lifion/core-commons` scaffolding block from `package.json`. The library no longer tracks that shared tooling (see #727).

`engines` is intentionally left alone here. The Node floor bump to 20+ is a breaking change and lands with v2.

## Verification

Green on Node 20, 22, and 24 locally: 430 tests, 100% coverage, lint clean (3 pre-existing warnings).
