### PR TITLE
fix: stop the state store and DynamoDB client on stopConsumer

### DIFF
--- a/lib/dynamodb-client.js
+++ b/lib/dynamodb-client.js
@@ -18,6 +18,7 @@ const { getStackObj, shouldBailRetry, transformErrorStack } = require('./utils')
 
 const privateData = new WeakMap();
 const statsSource = 'dynamoDb';
+const stoppedClients = new WeakSet();
 
 /**
  * Provides access to the private data of the specified instance.
@@ -82,6 +83,10 @@ async function sdkCall(client, methodName, ...args) {
 function retriableSdkCall(client, methodName, retryOpts, ...args) {
   const stackObj = getStackObj(retriableSdkCall);
   return retry((bail) => {
+    if (stoppedClients.has(client)) {
+      bail(new Error('The DynamoDB client is stopped.'));
+      return undefined;
+    }
     try {
       return client[methodName](...args)
         .promise()
@@ -145,6 +150,16 @@ class DynamoDbClient {
     };
 
     Object.assign(internal(this), { client, docClient, logger, retryOpts });
+  }
+
+  /**
+   * Stops the client. Pending and future retriable calls bail out instead of
+   * retrying, so the client stops holding the event loop open.
+   */
+  stop() {
+    const { client, docClient } = internal(this);
+    stoppedClients.add(client);
+    stoppedClients.add(docClient);
   }
 
   /**

--- a/lib/dynamodb-client.test.js
+++ b/lib/dynamodb-client.test.js
@@ -39,6 +39,7 @@ describe('lib/dynamodb-client', () => {
     expect(DynamoDbClient).toThrow('Class constructor');
     expect(Object.getOwnPropertyNames(DynamoDbClient.prototype)).toEqual([
       'constructor',
+      'stop',
       'createTable',
       'describeTable',
       'listTagsOfResource',
@@ -56,6 +57,14 @@ describe('lib/dynamodb-client', () => {
     client = new DynamoDbClient({ awsOptions });
     expect(client).toBeDefined();
     expect(DynamoDB).toHaveBeenCalledWith(awsOptions);
+  });
+
+  test('stop makes retriable calls bail out instead of retrying', async () => {
+    recreateClients(true);
+    client.stop();
+    await expect(client.get({})).rejects.toThrow('The DynamoDB client is stopped.');
+    expect(sdkClient.get).not.toHaveBeenCalled();
+    expect(warn).not.toHaveBeenCalled();
   });
 
   describe.each`

--- a/lib/index.js
+++ b/lib/index.js
@@ -454,12 +454,14 @@ class Kinesis extends PassThrough {
    */
   stopConsumer() {
     const privateProps = internal(this);
-    const { consumersManager, getStatsIntervalId, heartbeatManager, leaseManager } = privateProps;
+    const { consumersManager, getStatsIntervalId, heartbeatManager, leaseManager, stateStore } =
+      privateProps;
     heartbeatManager.stop();
     consumersManager.stop();
     leaseManager.stop();
     clearTimeout(getStatsIntervalId);
     privateProps.getStatsIntervalId = null;
+    stateStore.stop();
   }
 
   /**

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -95,12 +95,14 @@ jest.mock('./state-store', () => {
     delete enhancedConsumers[consumerName];
     return Promise.resolve();
   });
+  const stop = jest.fn();
   return jest.fn(() => ({
     clearMockData,
     deregisterEnhancedConsumer,
     getEnhancedConsumers,
     registerEnhancedConsumer,
-    start
+    start,
+    stop
   }));
 });
 

--- a/lib/state-store.js
+++ b/lib/state-store.js
@@ -853,6 +853,17 @@ class StateStore {
   }
 
   /**
+   * Stops the state store by stopping its DynamoDB client, so in-flight and
+   * future calls stop retrying and the client no longer holds the event loop.
+   *
+   * @returns {undefined}
+   */
+  stop() {
+    const { client } = internal(this);
+    client.stop();
+  }
+
+  /**
    * Store a shard checkpoint.
    *
    * @param {string} shardId - The ID of the shard to store a checkpoint for.

--- a/lib/state-store.test.js
+++ b/lib/state-store.test.js
@@ -10,8 +10,9 @@ jest.mock('./dynamodb-client', () => {
   const get = jest.fn(() => Promise.resolve({}));
   const put = jest.fn(() => Promise.resolve({}));
   const deleteMock = jest.fn(() => Promise.resolve({}));
+  const stop = jest.fn();
   const update = jest.fn(() => Promise.resolve({}));
-  return jest.fn(() => ({ delete: deleteMock, get, put, update }));
+  return jest.fn(() => ({ delete: deleteMock, get, put, stop, update }));
 });
 
 jest.mock('./table');
@@ -48,6 +49,7 @@ describe('lib/state-store', () => {
     client.delete.mockClear();
     client.get.mockClear();
     client.put.mockClear();
+    client.stop.mockClear();
     client.update.mockClear();
 
     DynamoDbClient.mockClear();
@@ -72,8 +74,17 @@ describe('lib/state-store', () => {
       'registerEnhancedConsumer',
       'releaseShardLease',
       'start',
+      'stop',
       'storeShardCheckpoint'
     ]);
+  });
+
+  test('stopping the state store stops the DynamoDB client', async () => {
+    const store = new StateStore(options);
+    await store.start();
+    store.stop();
+    const { stop } = new DynamoDbClient();
+    expect(stop).toHaveBeenCalled();
   });
 
   test('starting the state store will create a DynamoDB table', async () => {


### PR DESCRIPTION
Closes #337.

`stopConsumer()` stopped the internal managers but left the state store and its DynamoDB client running. Because those calls use `forever: true` retries, an in-flight call (for example one that was mid-flight when the backing store was torn down) kept retrying and held sockets open, so the process would not exit and jest reported open handles.

## Change

- `dynamodb-client.js`: add `stop()`, and make retriable calls bail out when the client is stopped (tracked in a module-level `WeakSet`).
- `state-store.js`: add `stop()` that stops its DynamoDB client.
- `index.js`: `stopConsumer()` now stops the state store.

The DynamoDB client is consume-only (the state store), so stopping it does not affect `putRecord`/`putRecords`, which share the Kinesis client.

## Scope

The Kinesis client has the same forever-retry behavior for in-flight reads, but it is shared with the producer path, so cancelling just the consumer reads is a separate, trickier change. Tracked as a follow-up in #748.

## Verification

- 434 unit tests pass at 100% coverage; eslint clean.
- The LocalStack integration suite confirms `startConsumer` then `stopConsumer` still shuts down cleanly.