### PR TITLE
fix: stop the consumer Kinesis client on stopConsumer

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -359,6 +359,13 @@ class Kinesis extends PassThrough {
         supressThroughputWarnings
       }),
       compression,
+      consumerClient: new KinesisClient({
+        awsOptions,
+        logger: normLogger,
+        retryOptions,
+        streamName,
+        supressThroughputWarnings
+      }),
       consumerGroup,
       consumerId: generate(),
       createStreamIfNeeded,
@@ -408,7 +415,7 @@ class Kinesis extends PassThrough {
    */
   async startConsumer() {
     const privateProps = internal(this);
-    const { logger, statsInterval, streamName, useEnhancedFanOut } = privateProps;
+    const { consumerClient, logger, statsInterval, streamName, useEnhancedFanOut } = privateProps;
 
     await ensureStreamInitialized(this);
 
@@ -432,7 +439,7 @@ class Kinesis extends PassThrough {
       }
     };
 
-    const consumersManager = new ConsumersManager(privateProps);
+    const consumersManager = new ConsumersManager({ ...privateProps, client: consumerClient });
     privateProps.consumersManager = consumersManager;
     await consumersManager.reconcile();
 
@@ -454,14 +461,21 @@ class Kinesis extends PassThrough {
    */
   stopConsumer() {
     const privateProps = internal(this);
-    const { consumersManager, getStatsIntervalId, heartbeatManager, leaseManager, stateStore } =
-      privateProps;
+    const {
+      consumerClient,
+      consumersManager,
+      getStatsIntervalId,
+      heartbeatManager,
+      leaseManager,
+      stateStore
+    } = privateProps;
     heartbeatManager.stop();
     consumersManager.stop();
     leaseManager.stop();
     clearTimeout(getStatsIntervalId);
     privateProps.getStatsIntervalId = null;
     stateStore.stop();
+    consumerClient.stop();
   }
 
   /**

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -54,7 +54,8 @@ jest.mock('./kinesis-client', () => {
       }))
     })
   );
-  return jest.fn(() => ({ isEndpointLocal: () => true, listShards, putRecord, putRecords }));
+  const stop = jest.fn();
+  return jest.fn(() => ({ isEndpointLocal: () => true, listShards, putRecord, putRecords, stop }));
 });
 
 jest.mock('./s3-client', () => {
@@ -156,6 +157,7 @@ describe('lib/index', () => {
     kinesisClient.listShards.mockClear();
     kinesisClient.putRecord.mockClear();
     kinesisClient.putRecords.mockClear();
+    kinesisClient.stop.mockClear();
 
     const leaseManager = new LeaseManager();
     leaseManager.start.mockClear();
@@ -359,6 +361,15 @@ describe('lib/index', () => {
     } finally {
       kinesis.stopConsumer();
     }
+  });
+
+  test('stopping a consumer stops its dedicated Kinesis client', async () => {
+    const kinesis = new Kinesis({ ...options });
+    await kinesis.startConsumer();
+    const { stop } = new KinesisClient();
+    expect(stop).not.toHaveBeenCalled();
+    kinesis.stopConsumer();
+    expect(stop).toHaveBeenCalledTimes(1);
   });
 
   test('invalid options in the constructor should be defaulted', async () => {

--- a/lib/kinesis-client.js
+++ b/lib/kinesis-client.js
@@ -30,6 +30,7 @@ const RETRIABLE_PUT_ERRORS = new Set([
 
 const privateData = new WeakMap();
 const statsSource = 'kinesis';
+const stoppedClients = new WeakSet();
 
 /**
  * Provides access to the private data of the specified instance.
@@ -96,6 +97,10 @@ async function sdkCall(client, methodName, streamName, ...args) {
 function retriableSdkCall(client, methodName, streamName, retryOpts, ...args) {
   const stackObj = getStackObj(retriableSdkCall);
   return retry((bail) => {
+    if (stoppedClients.has(client)) {
+      bail(new Error('The Kinesis client is stopped.'));
+      return undefined;
+    }
     try {
       return client[methodName](...args)
         .promise()
@@ -163,6 +168,14 @@ class KinesisClient {
     };
 
     Object.assign(internal(this), { client, retryOpts, streamName });
+  }
+
+  /**
+   * Stops the client so its pending and future retriable calls stop retrying.
+   */
+  stop() {
+    const { client } = internal(this);
+    stoppedClients.add(client);
   }
 
   /**

--- a/lib/kinesis-client.test.js
+++ b/lib/kinesis-client.test.js
@@ -62,6 +62,7 @@ describe('lib/kinesis-client', () => {
     expect(KinesisClient).toThrow('Class constructor');
     expect(Object.getOwnPropertyNames(KinesisClient.prototype)).toEqual([
       'constructor',
+      'stop',
       'addTagsToStream',
       'createStream',
       'deregisterStreamConsumer',
@@ -86,6 +87,14 @@ describe('lib/kinesis-client', () => {
     client = new KinesisClient({ awsOptions });
     expect(client).toBeDefined();
     expect(Kinesis).toHaveBeenCalledWith(awsOptions);
+  });
+
+  test('stop makes retriable calls bail out instead of retrying', async () => {
+    recreateClients();
+    client.stop();
+    await expect(client.getRecords({})).rejects.toThrow('The Kinesis client is stopped.');
+    expect(sdkClient.getRecords).not.toHaveBeenCalled();
+    expect(warn).not.toHaveBeenCalled();
   });
 
   test('retryOptions are merged into the retry behavior, overriding the defaults', async () => {

--- a/lib/polling-consumer.js
+++ b/lib/polling-consumer.js
@@ -197,6 +197,7 @@ async function pollForRecords(instance) {
       privateProps.timeoutId = setTimeout(pollForRecords, pollDelay, instance);
     }
   } catch (err) {
+    if (privateProps.stopped) return;
     if (err.code === 'ExpiredIteratorException') {
       logger.warn('Previous shard iterator expired, recreating…');
       privateProps.iterator = null;
@@ -296,6 +297,7 @@ class PollingConsumer {
       shouldDeaggregate,
       stateStore,
       stopConsumer,
+      stopped: false,
       streamName,
       timeoutId: null,
       useAutoCheckpoints,
@@ -343,12 +345,13 @@ class PollingConsumer {
   }
 
   /**
-   * Stops the timers that poll for records.
+   * Stops the consumer from polling for more records.
    */
   stop() {
     const privateProps = internal(this);
     clearTimeout(privateProps.timeoutId);
     privateProps.timeoutId = null;
+    privateProps.stopped = true;
   }
 
   /**

--- a/lib/polling-consumer.test.js
+++ b/lib/polling-consumer.test.js
@@ -293,6 +293,19 @@ describe('lib/polling-consumer', () => {
     });
   });
 
+  test('a stopped consumer swallows in-flight read errors instead of emitting them', async () => {
+    getShardIterator.mockRejectedValueOnce(new Error('The Kinesis client is stopped.'));
+    const consumer = new PollingConsumer(options);
+    consumer.stop();
+    await consumer.start();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(errorMock).not.toHaveBeenCalled();
+    expect(pushToStream).not.toHaveBeenCalled();
+  });
+
   test('the consumer stops when failing to resolve the shard state on start', async () => {
     getShardsData.mockImplementationOnce(() => {
       throw new Error('foo');


### PR DESCRIPTION
## What

Follow-up to #337/#749. `stopConsumer()` stopped the managers but left the polling consumer's Kinesis reads (`getRecords`/`getShardIterator`) retrying. With `forever: true`, a read that was in flight when the backing stream went away kept retrying and held the event loop open, so the process would not exit.

## How

The Kinesis client is shared with `putRecord`/`putRecords`, so it can't be stopped wholesale without breaking producing. So the consumers get their **own** Kinesis client (consume-only), and `stopConsumer()` stops just that one — mirroring how #749 stops the consume-only DynamoDB client.

- `kinesis-client.js`: a `stop()` method marks the client; retriable calls then bail instead of retrying. Producer puts use a separate inline retry path and are unaffected.
- `index.js`: build a dedicated `consumerClient` alongside the producer `client`, hand it to `ConsumersManager`, and `consumerClient.stop()` on `stopConsumer()`.
- `polling-consumer.js`: a read that bails after stop would otherwise reject into `pushToStream(err)` → `emit('error')` (which throws on a stream with no `error` listener). A `stopped` guard makes the consumer shut down quietly instead.

Fan-out was already covered — `FanOutConsumer.stop()` aborts its in-flight request and halts its retry pipeline. `lease-manager`/`heartbeat-manager` make no Kinesis SDK calls (the DynamoDB side is handled by #749).

## Testing

`jest` — 437 tests pass, 100% coverage. `eslint` — 0 errors.

Fixes #748
