### PR TITLE
fix: swallow conditional check failures in storeShardCheckpoint

### DIFF
--- a/lib/state-store.js
+++ b/lib/state-store.js
@@ -899,22 +899,29 @@ class StateStore {
 
     const { client, consumerGroup, streamName } = internal(this);
 
-    await client.update({
-      ExpressionAttributeNames: {
-        ...shardsPathNames,
-        '#b': shardId,
-        '#c': 'approximateArrivalTimestamp',
-        '#d': 'checkpoint',
-        '#e': 'version'
-      },
-      ExpressionAttributeValues: {
-        ':x': approximateArrivalTimestampString,
-        ':y': checkpoint,
-        ':z': generate()
-      },
-      Key: { consumerGroup, streamName },
-      UpdateExpression: `SET ${shardsPath}.#b.#c = :x, ${shardsPath}.#b.#d = :y, ${shardsPath}.#b.#e = :z`
-    });
+    try {
+      await client.update({
+        ExpressionAttributeNames: {
+          ...shardsPathNames,
+          '#b': shardId,
+          '#c': 'approximateArrivalTimestamp',
+          '#d': 'checkpoint',
+          '#e': 'version'
+        },
+        ExpressionAttributeValues: {
+          ':x': approximateArrivalTimestampString,
+          ':y': checkpoint,
+          ':z': generate()
+        },
+        Key: { consumerGroup, streamName },
+        UpdateExpression: `SET ${shardsPath}.#b.#c = :x, ${shardsPath}.#b.#d = :y, ${shardsPath}.#b.#e = :z`
+      });
+    } catch (err) {
+      if (err.code !== 'ConditionalCheckFailedException') {
+        logger.error(err);
+        throw err;
+      }
+    }
   }
 }
 

--- a/lib/state-store.test.js
+++ b/lib/state-store.test.js
@@ -1433,6 +1433,20 @@ describe('lib/state-store', () => {
     expect(update).toHaveBeenCalledTimes(1);
   });
 
+  test('storeShardCheckpoint ignores conditional update mismatches', async () => {
+    const store = new StateStore(options);
+    await store.start();
+    const { update } = new DynamoDbClient();
+    update.mockRejectedValueOnce(
+      Object.assign(new Error('foo'), { code: 'ConditionalCheckFailedException' })
+    );
+    await expect(
+      store.storeShardCheckpoint('shard-0001', '1', '#a', { '#a': 'a' }, new Date())
+    ).resolves.toBeUndefined();
+    expect(update).toHaveBeenCalledTimes(1);
+    expect(error).not.toHaveBeenCalled();
+  });
+
   test('storeShardCheckpoint throws if DynamoDB throws', async () => {
     const store = new StateStore(options);
     await store.start();
@@ -1441,5 +1455,6 @@ describe('lib/state-store', () => {
     await expect(
       store.storeShardCheckpoint('shard-0001', '1', '#a', { '#a': 'a' }, new Date())
     ).rejects.toThrow('foo');
+    expect(error).toHaveBeenCalledWith(expect.objectContaining({ message: 'foo' }));
   });
 });


### PR DESCRIPTION
## What

`storeShardCheckpoint` was the only shard-state write in the state store that didn't follow the convention of ignoring `ConditionalCheckFailedException`. Every sibling write (lease locking/releasing, consumer registration, shard-state creation, old-consumer cleanup, etc.) treats a conditional failure as a benign outcome of consumers racing over the shared state item and carries on.

## Why

Because the checkpoint write let the exception escape, a benign race surfaced as a fatal error to the caller:

- **Enhanced fan-out** (`useEnhancedFanOut: true`, the reporter's setup): the error reached the pipeline catch in `fan-out-consumer.js`. Since `ConditionalCheckFailedException` is on the bail-retry list, `shouldBailRetry` returns `true`, so the pipeline was torn down and `retryPipeline` set to `false` — **permanently stopping consumption of that shard**.
- **Polling**: the error was caught in `pollForRecords` and pushed to the consumer stream as an `error` event.

This matches the repeated `ConditionalCheckFailedException` stack traces reported in #384.

## Change

Wrap the update in the same `try/catch` the sibling methods use: swallow `ConditionalCheckFailedException`, log and rethrow anything else.

## Tests

- Added `storeShardCheckpoint ignores conditional update mismatches` (mirrors the existing `releaseShardLease` test).
- Tightened `storeShardCheckpoint throws if DynamoDB throws` to assert the error is logged on the rethrow path.
- Full suite: 438 passing, 100% coverage. eslint clean (only the 3 pre-existing baseline warnings).

Closes #384