### PR TITLE
test: guard against require() leaving the event loop alive

### DIFF
--- a/.github/workflows/pull-request-check.yml
+++ b/.github/workflows/pull-request-check.yml
@@ -32,6 +32,8 @@ jobs:
         run: npm test -- --ci --runInBand
         env:
           CI: true
+      - name: Run smoke test
+        run: npm run test:smoke
       - name: Report coverage
         uses: codecov/codecov-action@v4
         with:

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "postpublish": "pinst --enable",
     "test": "jest -c ./.jest.json",
     "test:integration": "vitest run -c vitest.integration.config.mjs",
+    "test:smoke": "vitest run -c vitest.smoke.config.mjs",
     "version": "auto-changelog -p && git add CHANGELOG.md"
   },
   "dependencies": {

--- a/test/smoke/require-exits.test.mjs
+++ b/test/smoke/require-exits.test.mjs
@@ -1,0 +1,43 @@
+import { execFile } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+
+import { describe, expect, it } from 'vitest';
+
+const execFileAsync = promisify(execFile);
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const entry = path.join(repoRoot, 'lib', 'index.js');
+
+// Requiring the client must not leave a handle that keeps the event loop alive,
+// or a bare `require('lifion-kinesis')` blocks the host process from exiting
+// (#474, caused by lzutf8 < 0.6.3 opening a MessagePort at require time). Run
+// the require in a child process: if a ref'd handle lingers, the child never
+// exits on its own and the timeout has to kill it, failing the test.
+describe('requiring the client', () => {
+  it('lets the process exit and opens no MessagePort', async () => {
+    const script = `require(${JSON.stringify(
+      entry
+    )});console.log(JSON.stringify(process.getActiveResourcesInfo()));`;
+
+    let stdout;
+    try {
+      ({ stdout } = await execFileAsync(process.execPath, ['-e', script], { timeout: 10_000 }));
+    } catch (err) {
+      if (err.killed) {
+        throw new Error(
+          'Requiring the client kept the event loop alive; the process had to be killed. ' +
+            "A dependency likely opened a ref'd handle at require time (see #474)."
+        );
+      }
+      throw err;
+    }
+
+    const resources = JSON.parse(stdout.trim());
+    expect(resources).not.toContain('MessagePort');
+    // The vitest timeout must exceed the child's execFile timeout so that, on a
+    // regression, the child is killed first and the assertion above reports it
+    // (rather than vitest timing out with a generic message).
+  }, 20_000);
+});

--- a/vitest.smoke.config.mjs
+++ b/vitest.smoke.config.mjs
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config';
+
+// Smoke suite: fast, no mocks, no LocalStack. Guards against regressions where
+// simply requiring the client leaves a handle that keeps the Node event loop
+// alive (see #474: lzutf8 < 0.6.3 opened a MessagePort at require time, so a
+// bare `require('lifion-kinesis')` blocked the host process from exiting).
+export default defineConfig({
+  test: {
+    coverage: { enabled: false },
+    environment: 'node',
+    include: ['test/smoke/**/*.test.mjs'],
+    reporters: ['default']
+  }
+});


### PR DESCRIPTION
## What

Adds a small smoke suite that requires the built client in a child process and asserts the process exits on its own and opens no `MessagePort`.

## Why

#474 ("Exit always blocked after require()") was caused by a transitive dependency — `lzutf8 < 0.6.3` opened a `MessagePort` at `require` time ([upstream fix](https://github.com/rotemdan/lzutf8.js/pull/50)), which is ref'd and keeps the Node event loop alive. Since the client loads `lzutf8` eagerly through its compression module, a bare `require('lifion-kinesis')` was enough to block the host process from exiting.

The `lzutf8@^0.6.3` bump resolved it, but nothing stops a future dependency from regressing the same way. This guards against any dependency that opens a ref'd handle at require time.

## How

- `test/smoke/require-exits.test.mjs` — spawns `node -e "require('lib/index.js')"` and fails if the child has to be killed (hang) or reports a `MessagePort`. No LocalStack, no mocks.
- `vitest.smoke.config.mjs` + `npm run test:smoke` — separate from the LocalStack integration suite (which has a `wait-for-localstack` global setup).
- Wired into the unit CI job (`Pull Request Check`), so it runs across the Node 20/22/24 × ubuntu/windows/macos matrix.

## Verification

- Passes on the current tree.
- Confirmed it **fails** (child hangs and is killed) when `lzutf8` is pinned back to 0.6.2, so it genuinely catches the regression.
- jest unaffected (438 passing); eslint clean.

Refs #474