### PR TITLE
ci: support maintenance branches for the v1.x line

### DIFF
--- a/.github/workflows/publish-module.yml
+++ b/.github/workflows/publish-module.yml
@@ -3,6 +3,16 @@ on:
   push:
     branches:
       - main
+  # Manual publishing for maintenance lines (e.g. support/1.x). Pick the npm
+  # dist-tag explicitly: keep `latest` while that line is the current major,
+  # and switch to a non-latest tag (e.g. `v1`) once a newer major owns `latest`.
+  workflow_dispatch:
+    inputs:
+      dist_tag:
+        description: 'npm dist-tag to publish under'
+        required: true
+        default: 'latest'
+        type: string
 jobs:
   install-and-check:
     name: Install & Check
@@ -43,6 +53,6 @@ jobs:
         env:
           DISABLE_OPENCOLLECTIVE: true
       - name: Publish
-        run: npm publish
+        run: npm publish --tag "${{ github.event.inputs.dist_tag || 'latest' }}"
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}

--- a/.github/workflows/pull-request-check.yml
+++ b/.github/workflows/pull-request-check.yml
@@ -3,9 +3,11 @@ on:
   push:
     branches:
       - develop
+      - 'support/**'
   pull_request:
     branches:
       - develop
+      - 'support/**'
 jobs:
   check:
     name: Node ${{ matrix.node-version }} on ${{ matrix.os }}


### PR DESCRIPTION
Prepares CI for a long-lived git-flow **`support/1.x`** branch, so v1 can be patched/backported after `develop` moves on to v2. Landing it in 1.4.0 means a `support/1.x` cut from the `v1.4.0` tag inherits the wiring.

## Changes
- **pull-request-check.yml**: also trigger on push/PR for `support/**`, so v1 maintenance changes get the same lint + Node matrix + smoke checks as `develop`.
- **publish-module.yml**: add a manual `workflow_dispatch` trigger with a `dist_tag` input (default `latest`) and pass it to `npm publish --tag`. Pushes to `main` are unchanged (the input is empty there, so it resolves to `latest`).

## Why the dist-tag input
While v1 is still the current major, v1 patches should publish as `latest`. Once v2.0.0 ships and owns `latest`, v1 patches must publish under a non-latest tag (e.g. `v1`) so `npm install lifion-kinesis` doesn't downgrade. The manual dispatch lets the maintainer pick the tag per release instead of hard-coding it.

## How a v1 patch would ship later
1. Branch `support/1.x` off the `v1.4.0` tag (one-time).
2. Fix on a `hotfix/1.4.1` branch off `support/1.x`, PR back into `support/1.x` (CI runs via this change).
3. Bump + tag `v1.4.1` on `support/1.x`.
4. Actions → **Publish Module** → **Run workflow** from `support/1.x`, choosing `dist_tag` (`latest` while v1 is current, `v1` after v2 ships).

Note: `workflow_dispatch` makes the publish workflow manually runnable from any branch that has it; it's gated by Actions access + the npm token, and the lint/test job runs first.