### PR TITLE
chore: exclude all vitest configs from the published package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,4 +7,4 @@
 /test
 __mocks__
 jsconfig.json
-vitest.integration.config.mjs
+vitest.*.config.mjs


### PR DESCRIPTION
`.npmignore` only excluded `vitest.integration.config.mjs`, so the smoke config added in #753 (`vitest.smoke.config.mjs`) was leaking into the published tarball. Broadened the pattern to `vitest.*.config.mjs` so the smoke config — and any future vitest config — stays out of the package.

Verified with `npm pack --dry-run`: no vitest config ships; `README.md`, `LICENSE`, `package.json`, and `lib/` are unaffected.

Small publish-hygiene cleanup to land before cutting 1.4.0.