### PR TITLE
ci: publish to npm via OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish-module.yml
+++ b/.github/workflows/publish-module.yml
@@ -3,9 +3,6 @@ on:
   push:
     branches:
       - main
-  # Manual publishing for maintenance lines (e.g. support/1.x). Pick the npm
-  # dist-tag explicitly: keep `latest` while that line is the current major,
-  # and switch to a non-latest tag (e.g. `v1`) once a newer major owns `latest`.
   workflow_dispatch:
     inputs:
       dist_tag:
@@ -39,6 +36,9 @@ jobs:
     name: NPM Publish
     needs: install-and-check
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Clone repository
         uses: actions/checkout@v6
@@ -48,11 +48,11 @@ jobs:
           check-latest: true
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
+      - name: Update npm
+        run: npm install -g npm@latest
       - name: Install
         run: npm ci --loglevel=error
         env:
           DISABLE_OPENCOLLECTIVE: true
       - name: Publish
-        run: npm publish --tag "${{ github.event.inputs.dist_tag || 'latest' }}"
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}
+        run: npm publish --provenance --tag "${{ github.event.inputs.dist_tag || 'latest' }}"


### PR DESCRIPTION
Switches the publish workflow from a long-lived `NPM_AUTH_TOKEN` to **npm trusted publishing (OIDC)**. This also unblocks the 1.4.0 release: `package.json` on `main` is already at 1.4.0, so merging this re-runs `publish-module.yml` with OIDC auth and publishes 1.4.0 (the previous run failed because the stored token dated to 2019 and no longer worked).

## Changes (`publish-module.yml`, npm-publish job)
- `permissions: id-token: write` (+ `contents: read`) so GitHub can mint the OIDC identity
- **Update npm** step — trusted publishing + provenance need npm ≥ 11.5.1; Node 20 ships npm 10
- publish with `--provenance`; **dropped `NODE_AUTH_TOKEN`**

## Prereq (done on npm side)
Trusted publisher configured on npmjs.com: GitHub Actions → `lifion` / `lifion-kinesis` / `publish-module.yml`, Allow `npm publish`.

## On merge
Push to `main` triggers the workflow → `install-and-check` → `npm-publish` publishes **1.4.0** via OIDC, with provenance, no token.

## After it's green
- Delete the stale `NPM_AUTH_TOKEN` repo secret (no longer used)
- (Follow-up) optionally add a GitHub Environment with required reviewers and set it on both the job and the npm trusted-publisher config, for approval-gated publishes