### PR TITLE
ci: automate tagging, releases, and the main→develop back-merge

### DIFF
--- a/.github/workflows/backmerge.yml
+++ b/.github/workflows/backmerge.yml
@@ -1,0 +1,27 @@
+name: Back-merge main into develop
+on:
+  push:
+    branches:
+      - main
+jobs:
+  open-back-merge:
+    name: Open back-merge PR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v6
+      - name: Open back-merge PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ -n "$(gh pr list --base develop --head main --state open --json number --jq '.[0].number // empty')" ]; then
+            echo "A back-merge PR is already open."
+            exit 0
+          fi
+          gh pr create --base develop --head main \
+            --title "Sync main into develop" \
+            --body "Automated back-merge of main into develop." \
+            || echo "Nothing to back-merge."

--- a/.github/workflows/publish-module.yml
+++ b/.github/workflows/publish-module.yml
@@ -55,4 +55,33 @@ jobs:
         env:
           DISABLE_OPENCOLLECTIVE: true
       - name: Publish
-        run: npm publish --provenance --tag "${{ github.event.inputs.dist_tag || 'latest' }}"
+        run: |
+          pkg=$(node -p "require('./package.json').name")
+          version=$(node -p "require('./package.json').version")
+          if npm view "${pkg}@${version}" version > /dev/null 2>&1; then
+            echo "${pkg}@${version} is already published; skipping."
+          else
+            npm publish --provenance --tag "${{ github.event.inputs.dist_tag || 'latest' }}"
+          fi
+  release:
+    name: Tag & GitHub Release
+    needs: npm-publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v6
+      - name: Resolve version
+        id: version
+        run: echo "value=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+      - name: Tag and release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag="v${{ steps.version.outputs.value }}"
+          if gh release view "$tag" > /dev/null 2>&1; then
+            echo "Release $tag already exists; skipping."
+          else
+            gh release create "$tag" --title "$tag" --target "$GITHUB_SHA" --generate-notes
+          fi

--- a/.github/workflows/pull-request-check.yml
+++ b/.github/workflows/pull-request-check.yml
@@ -4,10 +4,12 @@ on:
     branches:
       - develop
       - 'support/**'
+      - 'release/**'
   pull_request:
     branches:
       - develop
       - 'support/**'
+      - main
 jobs:
   check:
     name: Node ${{ matrix.node-version }} on ${{ matrix.os }}

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lifion/lifion-kinesis.git"
+    "url": "git+https://github.com/lifion/lifion-kinesis.git"
   },
   "bugs": {
     "url": "https://github.com/lifion/lifion-kinesis/issues"


### PR DESCRIPTION
Rounds out the release pipeline so a release is hands-off after the merge to `main`, and so non-release pushes to `main` are safe. Based on `main` (per the "resolve in main, then resync support/1.x" plan); merging it bootstraps its own back-merge to `develop`.

## Changes
- **Idempotent publish** (`publish-module.yml`): the publish step skips when the version is already on npm, so a push to `main` that isn't a version bump no longer fails trying to republish.
- **Tag & GitHub Release job** (`publish-module.yml`): after publish, creates the tag + a GitHub Release (generated notes) for the version, skipping if it already exists. (Releases had lapsed — last was v1.3.1; I've separately backfilled the 15 missing ones.)
- **Back-merge automation** (`backmerge.yml`): opens a `main → develop` sync PR on every push to `main`, so it's never forgotten.
- **Release-branch CI** (`pull-request-check.yml`): also runs on `release/**` pushes and PRs into `main`, so human-authored release/hotfix branches get the full matrix before reaching `main`.
- **`repository.url`** normalized to `git+https://…` (`npm pkg fix`).

## Safe to merge now
On merge, `publish-module` runs but **skips** (1.4.0 already published, v1.4.0 release exists); the only effect is `backmerge.yml` opening the `main → develop` PR that carries this into `develop`.

## Caveat
The back-merge PR is opened by `GITHUB_TOKEN`, so it won't auto-run checks (GitHub suppresses workflow runs for token-created events). Admin-merge it as usual.

## Follow-ups after this lands
- Resync `support/1.x` with `main` (so the maintenance line gets all of this) before v2 work.
- Delete the stale `NPM_AUTH_TOKEN` secret.
- For future releases, bump with `npm version --no-git-tag-version` so CI owns the tag (avoids double-tagging).