### PR TITLE
refactor: replace private-data WeakMap with #data fields

### DIFF
--- a/lib/consumers-manager.js
+++ b/lib/consumers-manager.js
@@ -10,26 +10,14 @@
 const FanOutConsumer = require('./fan-out-consumer');
 const PollingConsumer = require('./polling-consumer');
 
-const privateData = new WeakMap();
-
-/**
- * Provides access to the private data of the specified instance.
- *
- * @param {Object} instance - The private data's owner.
- * @returns {Object} The private data.
- * @private
- */
-function internal(instance) {
-  if (!privateData.has(instance)) privateData.set(instance, {});
-  return privateData.get(instance);
-}
-
 /**
  * Class that implements the consumers manager module.
  *
  * @alias module:consumers-manager
  */
 class ConsumersManager {
+  #data = {};
+
   /**
    * Initializes an instance of the consumers manager.
    *
@@ -83,7 +71,7 @@ class ConsumersManager {
       useS3ForLargeItems
     } = options;
 
-    Object.assign(internal(this), {
+    Object.assign(this.#data, {
       awsOptions,
       client,
       compression,
@@ -137,7 +125,7 @@ class ConsumersManager {
       useEnhancedFanOut,
       usePausedPolling,
       useS3ForLargeItems
-    } = internal(this);
+    } = this.#data;
 
     logger.debug('Reconciling shard consumers…');
 
@@ -243,7 +231,7 @@ class ConsumersManager {
    * @returns {undefined}
    */
   stop() {
-    const { consumers } = internal(this);
+    const { consumers } = this.#data;
     Object.keys(consumers).forEach((shardId) => consumers[shardId].stop());
   }
 }

--- a/lib/dynamodb-client.js
+++ b/lib/dynamodb-client.js
@@ -16,21 +16,8 @@ const { DynamoDB } = require('aws-sdk');
 const { reportError, reportResponse } = require('./stats');
 const { getStackObj, shouldBailRetry, transformErrorStack } = require('./utils');
 
-const privateData = new WeakMap();
 const statsSource = 'dynamoDb';
 const stoppedClients = new WeakSet();
-
-/**
- * Provides access to the private data of the specified instance.
- *
- * @param {Object} instance - The private data's owner.
- * @returns {Object} The private data.
- * @private
- */
-function internal(instance) {
-  if (!privateData.has(instance)) privateData.set(instance, {});
-  return privateData.get(instance);
-}
 
 /**
  * Calls a method on the given instance of AWS.DynamoDB. The call is promisified, the call stack
@@ -115,6 +102,8 @@ function retriableSdkCall(client, methodName, retryOpts, ...args) {
  * @alias module:dynamodb-client
  */
 class DynamoDbClient {
+  #data = {};
+
   /**
    * Initializes the AWS.DynamoDB internal instance and prepares the retry logic.
    *
@@ -149,7 +138,7 @@ class DynamoDbClient {
       randomize: true
     };
 
-    Object.assign(internal(this), { client, docClient, logger, retryOpts });
+    Object.assign(this.#data, { client, docClient, logger, retryOpts });
   }
 
   /**
@@ -157,7 +146,7 @@ class DynamoDbClient {
    * retrying, so the client stops holding the event loop open.
    */
   stop() {
-    const { client, docClient } = internal(this);
+    const { client, docClient } = this.#data;
     stoppedClients.add(client);
     stoppedClients.add(docClient);
   }
@@ -169,7 +158,7 @@ class DynamoDbClient {
    * @returns {Promise}
    */
   async createTable(...args) {
-    const { client, logger } = internal(this);
+    const { client, logger } = this.#data;
     try {
       await sdkCall(client, 'createTable', ...args);
       return undefined;
@@ -190,7 +179,7 @@ class DynamoDbClient {
    * @returns {Promise}
    */
   describeTable(...args) {
-    const { client, retryOpts } = internal(this);
+    const { client, retryOpts } = this.#data;
     return retriableSdkCall(client, 'describeTable', retryOpts, ...args);
   }
 
@@ -201,7 +190,7 @@ class DynamoDbClient {
    * @returns {Promise}
    */
   listTagsOfResource(...args) {
-    const { client, retryOpts } = internal(this);
+    const { client, retryOpts } = this.#data;
     return retriableSdkCall(client, 'listTagsOfResource', retryOpts, ...args);
   }
 
@@ -212,7 +201,7 @@ class DynamoDbClient {
    * @returns {Promise}
    */
   async tagResource(...args) {
-    const { client, logger } = internal(this);
+    const { client, logger } = this.#data;
     try {
       await sdkCall(client, 'tagResource', ...args);
       return undefined;
@@ -232,7 +221,7 @@ class DynamoDbClient {
    * @returns {Promise}
    */
   waitFor(...args) {
-    const { client, retryOpts } = internal(this);
+    const { client, retryOpts } = this.#data;
     return retriableSdkCall(client, 'waitFor', retryOpts, ...args);
   }
 
@@ -243,7 +232,7 @@ class DynamoDbClient {
    * @returns {Promise}
    */
   delete(...args) {
-    const { docClient } = internal(this);
+    const { docClient } = this.#data;
     return sdkCall(docClient, 'delete', ...args);
   }
 
@@ -255,7 +244,7 @@ class DynamoDbClient {
    * @returns {Promise}
    */
   get(...args) {
-    const { docClient, retryOpts } = internal(this);
+    const { docClient, retryOpts } = this.#data;
     return retriableSdkCall(docClient, 'get', retryOpts, ...args);
   }
 
@@ -267,7 +256,7 @@ class DynamoDbClient {
    * @returns {Promise}
    */
   put(...args) {
-    const { docClient, retryOpts } = internal(this);
+    const { docClient, retryOpts } = this.#data;
     return retriableSdkCall(docClient, 'put', retryOpts, ...args);
   }
 
@@ -279,7 +268,7 @@ class DynamoDbClient {
    * @returns {Promise}
    */
   update(...args) {
-    const { docClient, retryOpts } = internal(this);
+    const { docClient, retryOpts } = this.#data;
     return retriableSdkCall(docClient, 'update', retryOpts, ...args);
   }
 }

--- a/lib/fan-out-consumer.js
+++ b/lib/fan-out-consumer.js
@@ -80,6 +80,16 @@ class Deaggregate extends Transform {
 }
 
 /**
+ * The flags tracking the state of a shard subscription request.
+ *
+ * @typedef {Object} RequestFlags
+ * @property {boolean} isEventStream - If the request is sucessful and the headers in the initial
+ *        response point to an even stream, this flag is set to `true`.
+ * @property {number} statusCode - The status code of the last request response.
+ * @private
+ */
+
+/**
  * Class that implements a pre-processing stream used as a filter to a stream request to the
  * shard subscription API. If the request is successful and the response is an event stream,
  * chunks are passed to subsequent streams in the pipeline. If the server responds with an error,
@@ -96,10 +106,7 @@ class PreProcess extends Transform {
    * Initializes an instance of the pre-processing stream.
    *
    * @param {Object} options - The initialization options.
-   * @param {Object} options.requestFlags - The object where the flags for the request are stored.
-   * @param {boolean} options.requestFlags.isEventStream - If the request is sucessful and the
-   *        headers in the initial response point to an even stream, this flag is set to `true`.
-   * @param {number} options.requestFlags.statusCode - The status code of the last request response.
+   * @param {RequestFlags} options.requestFlags - The object where the flags for the request are stored.
    */
   constructor({ requestFlags }) {
     super({ objectMode: true });

--- a/lib/fan-out-consumer.js
+++ b/lib/fan-out-consumer.js
@@ -27,22 +27,7 @@ const DEFAULT_KINESIS_ENDPOINT = 'https://kinesis.us-east-1.amazonaws.com';
 const EXPIRATION_TIMEOUT_OFFSET = 1000;
 
 const asyncPipeline = promisify(pipeline);
-const privateData = new WeakMap();
 const wait = promisify(setTimeout);
-
-/**
- * Provides access to the private data of the specified instance.
- *
- * @param {Object} instance - The private data's owner.
- * @returns {Object} The private data.
- * @private
- */
-function internal(instance) {
-  if (!privateData.has(instance)) {
-    privateData.set(instance, {});
-  }
-  return privateData.get(instance);
-}
 
 /**
  * Class that implements a deaggregation stream used to the convert aggregated
@@ -55,6 +40,8 @@ function internal(instance) {
  */
 
 class Deaggregate extends Transform {
+  #data = {};
+
   /**
    * Initializes an instance of the deaggregation stream.
    *
@@ -63,7 +50,7 @@ class Deaggregate extends Transform {
    */
   constructor({ logger }) {
     super({ objectMode: true });
-    Object.assign(internal(this), { logger });
+    Object.assign(this.#data, { logger });
   }
 
   /**
@@ -74,7 +61,7 @@ class Deaggregate extends Transform {
    * @param {Function} callback - The callback for more data.
    */
   async _transform(chunk, encoding, callback) {
-    const { logger } = internal(this);
+    const { logger } = this.#data;
 
     try {
       if (!chunk || !chunk.payload || !chunk.payload.Records) {
@@ -103,6 +90,8 @@ class Deaggregate extends Transform {
  * @private
  */
 class PreProcess extends Transform {
+  #data = {};
+
   /**
    * Initializes an instance of the pre-processing stream.
    *
@@ -114,7 +103,7 @@ class PreProcess extends Transform {
    */
   constructor({ requestFlags }) {
     super({ objectMode: true });
-    Object.assign(internal(this), { requestFlags });
+    Object.assign(this.#data, { requestFlags });
   }
 
   /**
@@ -125,7 +114,7 @@ class PreProcess extends Transform {
    * @param {Function} callback - The callback for more data.
    */
   _transform(chunk, encoding, callback) {
-    const { requestFlags } = internal(this);
+    const { requestFlags } = this.#data;
     if (!requestFlags.isEventStream) {
       const { statusCode } = requestFlags;
       try {
@@ -161,6 +150,8 @@ class PreProcess extends Transform {
  * @private
  */
 class PostProcess extends Writable {
+  #data = {};
+
   /**
    * Initializes an instance of the post-processing stream.
    *
@@ -176,7 +167,7 @@ class PostProcess extends Writable {
    */
   constructor({ abort, logger, markShardAsDepleted, pushToStream, setCheckpoint, shardId }) {
     super({ objectMode: true });
-    Object.assign(internal(this), {
+    Object.assign(this.#data, {
       abort,
       logger,
       markShardAsDepleted,
@@ -188,7 +179,7 @@ class PostProcess extends Writable {
   }
 
   cancelTimeout() {
-    const { timeoutId } = internal(this);
+    const { timeoutId } = this.#data;
     clearTimeout(timeoutId);
   }
 
@@ -201,9 +192,9 @@ class PostProcess extends Writable {
    */
   async _write(chunk, encoding, callback) {
     const { abort, logger, markShardAsDepleted, pushToStream, setCheckpoint, shardId, timeoutId } =
-      internal(this);
+      this.#data;
     clearTimeout(timeoutId);
-    internal(this).timeoutId = setTimeout(abort, 10000);
+    this.#data.timeoutId = setTimeout(abort, 10000);
     const { continuationSequenceNumber, millisBehindLatest, records } = chunk;
     if (continuationSequenceNumber !== undefined) {
       await setCheckpoint(continuationSequenceNumber);
@@ -226,6 +217,8 @@ class PostProcess extends Writable {
  * @alias module:fan-out-consumer
  */
 class FanOutConsumer {
+  #data = {};
+
   /**
    * Initializes an instance of an enhanced fan-out consumer.
    *
@@ -306,7 +299,7 @@ class FanOutConsumer {
       throwHttpErrors: false
     });
 
-    Object.assign(internal(this), {
+    Object.assign(this.#data, {
       checkpoint,
       client,
       compression,
@@ -338,7 +331,7 @@ class FanOutConsumer {
    * @returns {Promise}
    */
   async start() {
-    const privateProps = internal(this);
+    const privateProps = this.#data;
     const {
       client,
       compression,
@@ -502,7 +495,7 @@ class FanOutConsumer {
    * Stops the internal stream pipeline.
    */
   stop() {
-    const privateProps = internal(this);
+    const privateProps = this.#data;
     const { expirationTimeoutId, request, stream } = privateProps;
     if (request) {
       request.abort();
@@ -523,7 +516,7 @@ class FanOutConsumer {
    * @param {string} leaseExpiration - The updated timestamp when the shard lease expires.
    */
   updateLeaseExpiration(leaseExpiration) {
-    const privateProps = internal(this);
+    const privateProps = this.#data;
     const { expirationTimeoutId, logger, shardId, stopConsumer } = privateProps;
 
     privateProps.leaseExpiration = leaseExpiration;

--- a/lib/heartbeat-manager.js
+++ b/lib/heartbeat-manager.js
@@ -14,26 +14,14 @@
 const HEARTBEAT_INTERVAL = 20 * 1000;
 const HEARTBEAT_FAILURE_TIMEOUT = HEARTBEAT_INTERVAL * 2;
 
-const privateData = new WeakMap();
-
-/**
- * Provides access to the private data of the specified instance.
- *
- * @param {Object} instance - The private data's owner.
- * @returns {Object} The private data.
- * @private
- */
-function internal(instance) {
-  if (!privateData.has(instance)) privateData.set(instance, {});
-  return privateData.get(instance);
-}
-
 /**
  * Class that implements the heartbeat manager.
  *
  * @alias module:heartbeat-manager
  */
 class HeartbeatManager {
+  #data = {};
+
   /**
    * Initializes an instance of the hearbeat manager.
    *
@@ -42,7 +30,7 @@ class HeartbeatManager {
    * @param {Object} options.stateStore - An instance of the state store.
    */
   constructor({ logger, stateStore }) {
-    Object.assign(internal(this), { logger, stateStore });
+    Object.assign(this.#data, { logger, stateStore });
   }
 
   /**
@@ -53,7 +41,7 @@ class HeartbeatManager {
    * @returns {Promise}
    */
   async start() {
-    const privateProps = internal(this);
+    const privateProps = this.#data;
     const { logger, stateStore, timeoutId } = privateProps;
 
     if (timeoutId) return;
@@ -76,7 +64,7 @@ class HeartbeatManager {
    * Stops the hearbeat interval.
    */
   stop() {
-    const privateProps = internal(this);
+    const privateProps = this.#data;
     const { timeoutId } = privateProps;
     clearTimeout(timeoutId);
     privateProps.timeoutId = null;

--- a/lib/index.js
+++ b/lib/index.js
@@ -34,31 +34,17 @@ const {
 
 const MAX_ENHANCED_CONSUMER_PER_CREATION = 5;
 
-const privateData = new WeakMap();
-
-/**
- * Provides access to the private data of the specified instance.
- *
- * @param {Object} instance - The private data's owner.
- * @returns {Object} The private data.
- * @private
- */
-function internal(instance) {
-  if (!privateData.has(instance)) privateData.set(instance, {});
-  return privateData.get(instance);
-}
-
 /**
  * Ensures a Kinesis stream exists and that is encrypted and tagged as required.
  *
- * @param {Object} instance - The instance of the Kinesis class where the call originated from.
+ * @param {Object} props - The private data of the Kinesis instance.
  * @param {string} [streamName] - The name of the stream to check initialization for.
  * @fulfil {undefined}
  * @returns {Promise}
  * @private
  */
-async function ensureStreamInitialized(instance, streamName) {
-  const privateProps = internal(instance);
+async function ensureStreamInitialized(props, streamName) {
+  const privateProps = props;
   const { compression, logger, s3, useS3ForLargeItems } = privateProps;
 
   let params;
@@ -109,13 +95,12 @@ async function ensureStreamInitialized(instance, streamName) {
  * stream reflects the existing enhanced consumers. Stale state will be removed, existing enhanced
  * consumers will be preserved.
  *
- * @param {Object} instance - A reference to the instance of the Kinesis class.
+ * @param {Object} privateProps - The private data of the Kinesis instance.
  * @returns {Promise}
  * @private
  */
-async function setUpEnhancedConsumers(instance) {
-  const { client, logger, maxEnhancedConsumers, stateStore, streamArn, streamName } =
-    internal(instance);
+async function setUpEnhancedConsumers(privateProps) {
+  const { client, logger, maxEnhancedConsumers, stateStore, streamArn, streamName } = privateProps;
   logger.debug(`Cleaning up enhanced consumers for "${streamName}"…`);
 
   // Retrieve the existing enhanced fan-out consumers for the stream.
@@ -195,6 +180,8 @@ function parsePutRecordsResult({ EncryptionType, Records }) {
  * @augments external:PassThrough
  */
 class Kinesis extends PassThrough {
+  #data = {};
+
   /**
    * Initializes a new instance of the Kinesis client.
    *
@@ -351,7 +338,7 @@ class Kinesis extends PassThrough {
           streamName
         });
 
-    Object.assign(internal(this), {
+    Object.assign(this.#data, {
       awsOptions,
       client: new KinesisClient({
         awsOptions,
@@ -416,10 +403,10 @@ class Kinesis extends PassThrough {
    * @returns {Promise}
    */
   async startConsumer() {
-    const privateProps = internal(this);
+    const privateProps = this.#data;
     const { consumerClient, logger, statsInterval, streamName, useEnhancedFanOut } = privateProps;
 
-    await ensureStreamInitialized(this);
+    await ensureStreamInitialized(privateProps);
 
     logger.debug('Trying to start the consumer…');
 
@@ -427,7 +414,7 @@ class Kinesis extends PassThrough {
     privateProps.stateStore = stateStore;
     await stateStore.start();
 
-    if (useEnhancedFanOut) await setUpEnhancedConsumers(this);
+    if (useEnhancedFanOut) await setUpEnhancedConsumers(privateProps);
 
     const heartbeatManager = new HeartbeatManager(privateProps);
     privateProps.heartbeatManager = heartbeatManager;
@@ -462,7 +449,7 @@ class Kinesis extends PassThrough {
    * Stops the stream consumer. The internal managers will also be stopped.
    */
   stopConsumer() {
-    const privateProps = internal(this);
+    const privateProps = this.#data;
     const {
       consumerClient,
       consumersManager,
@@ -500,13 +487,13 @@ class Kinesis extends PassThrough {
    * @returns {Promise}
    */
   async putRecord(params = {}) {
-    const privateProps = internal(this);
+    const privateProps = this.#data;
     const { client, createStreamIfNeeded } = privateProps;
     let { recordsEncoder } = privateProps;
     const { streamName, ...record } = params;
 
     if (!recordsEncoder) {
-      await ensureStreamInitialized(this, streamName);
+      await ensureStreamInitialized(privateProps, streamName);
       ({ recordsEncoder } = privateProps);
     }
 
@@ -522,7 +509,7 @@ class Kinesis extends PassThrough {
         code === 'ResourceNotFoundException' ||
         (code === 'UnknownError' && client.isEndpointLocal());
       if (createStreamIfNeeded && streamDoesNotExist) {
-        await ensureStreamInitialized(this, streamName);
+        await ensureStreamInitialized(privateProps, streamName);
         return parsePutRecordResult(await client.putRecord(awsParams));
       }
       throw err;
@@ -540,7 +527,7 @@ class Kinesis extends PassThrough {
    * @returns {Promise}
    */
   async listShards(params = {}) {
-    const privateProps = internal(this);
+    const privateProps = this.#data;
     const { client } = privateProps;
     const { streamName } = params;
 
@@ -580,13 +567,13 @@ class Kinesis extends PassThrough {
    * @returns {Promise}
    */
   async putRecords(params = {}) {
-    const privateProps = internal(this);
+    const privateProps = this.#data;
     const { client, createStreamIfNeeded } = privateProps;
     let { recordsEncoder } = privateProps;
     const { records, streamName } = params;
 
     if (!recordsEncoder) {
-      await ensureStreamInitialized(this, streamName);
+      await ensureStreamInitialized(privateProps, streamName);
       ({ recordsEncoder } = privateProps);
     }
 
@@ -604,7 +591,7 @@ class Kinesis extends PassThrough {
         code === 'ResourceNotFoundException' ||
         (code === 'UnknownError' && client.isEndpointLocal());
       if (createStreamIfNeeded && streamDoesNotExist) {
-        await ensureStreamInitialized(this, streamName);
+        await ensureStreamInitialized(privateProps, streamName);
         return parsePutRecordsResult(await client.putRecords(awsParams));
       }
       throw err;
@@ -617,7 +604,7 @@ class Kinesis extends PassThrough {
    * @returns {Object} An object with the statistics.
    */
   getStats() {
-    const { streamName } = internal(this);
+    const { streamName } = this.#data;
     return getStats(streamName);
   }
 

--- a/lib/kinesis-client.js
+++ b/lib/kinesis-client.js
@@ -28,21 +28,8 @@ const RETRIABLE_PUT_ERRORS = new Set([
   'TimeoutError'
 ]);
 
-const privateData = new WeakMap();
 const statsSource = 'kinesis';
 const stoppedClients = new WeakSet();
-
-/**
- * Provides access to the private data of the specified instance.
- *
- * @param {Object} instance - The private data's owner.
- * @returns {Object} The private data.
- * @private
- */
-function internal(instance) {
-  if (!privateData.has(instance)) privateData.set(instance, {});
-  return privateData.get(instance);
-}
 
 /**
  * Calls a method on the given instance of AWS.Kinesis. The call is promisified, the call stack
@@ -129,6 +116,8 @@ function retriableSdkCall(client, methodName, streamName, retryOpts, ...args) {
  * @alias module:kinesis-client
  */
 class KinesisClient {
+  #data = {};
+
   /**
    * Initializes the AWS.Kinesis internal instance and prepares the retry logic.
    *
@@ -167,14 +156,14 @@ class KinesisClient {
       ...retryOptions
     };
 
-    Object.assign(internal(this), { client, retryOpts, streamName });
+    Object.assign(this.#data, { client, retryOpts, streamName });
   }
 
   /**
    * Stops the client so its pending and future retriable calls stop retrying.
    */
   stop() {
-    const { client } = internal(this);
+    const { client } = this.#data;
     stoppedClients.add(client);
   }
 
@@ -185,7 +174,7 @@ class KinesisClient {
    * @returns {Promise}
    */
   addTagsToStream(...args) {
-    const { client, streamName } = internal(this);
+    const { client, streamName } = this.#data;
     return sdkCall(client, 'addTagsToStream', streamName, ...args);
   }
 
@@ -196,7 +185,7 @@ class KinesisClient {
    * @returns {Promise}
    */
   createStream(...args) {
-    const { client, streamName } = internal(this);
+    const { client, streamName } = this.#data;
     return sdkCall(client, 'createStream', streamName, ...args).catch((err) => {
       if (err.code !== 'ResourceInUseException') throw err;
     });
@@ -209,7 +198,7 @@ class KinesisClient {
    * @returns {Promise}
    */
   deregisterStreamConsumer(...args) {
-    const { client, streamName } = internal(this);
+    const { client, streamName } = this.#data;
     return sdkCall(client, 'deregisterStreamConsumer', streamName, ...args);
   }
 
@@ -220,7 +209,7 @@ class KinesisClient {
    * @returns {Promise}
    */
   describeStream(...args) {
-    const { client, retryOpts, streamName } = internal(this);
+    const { client, retryOpts, streamName } = this.#data;
     return retriableSdkCall(client, 'describeStream', streamName, retryOpts, ...args);
   }
 
@@ -231,7 +220,7 @@ class KinesisClient {
    * @returns {Promise}
    */
   describeStreamSummary(...args) {
-    const { client, retryOpts, streamName } = internal(this);
+    const { client, retryOpts, streamName } = this.#data;
 
     return sdkCall(client, 'describeStreamSummary', streamName, ...args).catch((err) => {
       if (err.code !== 'UnknownOperationException') throw err;
@@ -252,7 +241,7 @@ class KinesisClient {
    * @returns {Promise}
    */
   getRecords(...args) {
-    const { client, retryOpts, streamName } = internal(this);
+    const { client, retryOpts, streamName } = this.#data;
     return retriableSdkCall(client, 'getRecords', streamName, retryOpts, ...args);
   }
 
@@ -263,7 +252,7 @@ class KinesisClient {
    * @returns {Promise}
    */
   getShardIterator(...args) {
-    const { client, retryOpts, streamName } = internal(this);
+    const { client, retryOpts, streamName } = this.#data;
     return retriableSdkCall(client, 'getShardIterator', streamName, retryOpts, ...args);
   }
 
@@ -273,7 +262,7 @@ class KinesisClient {
    * @returns {boolean} `true` if the endpoints is local, `false` otherwise.
    */
   isEndpointLocal() {
-    const { client } = internal(this);
+    const { client } = this.#data;
     const { host } = client.endpoint;
     return host.includes('localhost') || host.includes('localstack');
   }
@@ -285,7 +274,7 @@ class KinesisClient {
    * @returns {Promise}
    */
   listShards(...args) {
-    const { client, retryOpts, streamName } = internal(this);
+    const { client, retryOpts, streamName } = this.#data;
     return retriableSdkCall(client, 'listShards', streamName, retryOpts, ...args);
   }
 
@@ -297,7 +286,7 @@ class KinesisClient {
    * @returns {Promise}
    */
   listStreamConsumers(...args) {
-    const { client, retryOpts, streamName } = internal(this);
+    const { client, retryOpts, streamName } = this.#data;
     return retriableSdkCall(client, 'listStreamConsumers', streamName, retryOpts, ...args);
   }
 
@@ -308,7 +297,7 @@ class KinesisClient {
    * @returns {Promise}
    */
   listTagsForStream(...args) {
-    const { client, retryOpts, streamName } = internal(this);
+    const { client, retryOpts, streamName } = this.#data;
     return retriableSdkCall(client, 'listTagsForStream', streamName, retryOpts, ...args);
   }
 
@@ -319,7 +308,7 @@ class KinesisClient {
    * @returns {Promise}
    */
   putRecord(...args) {
-    const { client, retryOpts, streamName } = internal(this);
+    const { client, retryOpts, streamName } = this.#data;
     const stackObj = getStackObj(retriableSdkCall);
     return retry((bail) => {
       try {
@@ -354,7 +343,7 @@ class KinesisClient {
    * @returns {Promise}
    */
   putRecords(...args) {
-    const { client, retryOpts, streamName } = internal(this);
+    const { client, retryOpts, streamName } = this.#data;
     const stackObj = getStackObj(retriableSdkCall);
     const [firstArg, ...restOfArgs] = args;
     let records = firstArg.Records;
@@ -407,7 +396,7 @@ class KinesisClient {
    * @returns {Promise}
    */
   registerStreamConsumer(...args) {
-    const { client, streamName } = internal(this);
+    const { client, streamName } = this.#data;
     return sdkCall(client, 'registerStreamConsumer', streamName, ...args);
   }
 
@@ -418,7 +407,7 @@ class KinesisClient {
    * @returns {Promise}
    */
   startStreamEncryption(...args) {
-    const { client, streamName } = internal(this);
+    const { client, streamName } = this.#data;
     return sdkCall(client, 'startStreamEncryption', streamName, ...args).catch((err) => {
       const { code } = err;
       if (code !== 'UnknownOperationException' && code !== 'ResourceInUseException') throw err;
@@ -432,7 +421,7 @@ class KinesisClient {
    * @returns {Promise}
    */
   waitFor(...args) {
-    const { client, retryOpts, streamName } = internal(this);
+    const { client, retryOpts, streamName } = this.#data;
     return retriableSdkCall(client, 'waitFor', streamName, retryOpts, ...args);
   }
 }

--- a/lib/lease-manager.js
+++ b/lib/lease-manager.js
@@ -21,19 +21,6 @@ const ACQUIRE_LEASES_RECOVERY_INTERVAL = 5 * 1000;
 const LEASE_TERM_TIMEOUT = 5 * 60 * 1000;
 const LEASE_RENEWAL_OFFSET = Math.round(LEASE_TERM_TIMEOUT * 0.25);
 
-const privateData = new WeakMap();
-
-/**
- * Provides access to the private data of the specified instance.
- *
- * @param {Object} instance - The private data's owner.
- * @returns {Object} The private data.
- */
-function internal(instance) {
-  if (!privateData.has(instance)) privateData.set(instance, {});
-  return privateData.get(instance);
-}
-
 /**
  * Tries to acquire the lease for a specific shard. The lease won't be acquired or renewed if:
  *
@@ -47,14 +34,13 @@ function internal(instance) {
  * about to expire. The lease will be released the lease owner is gone of if the lease expired.
  * Which would make the shard available for leasing for the next leasing attempt.
  *
- * @param {Object} instance - The instance of Lease Manager from which the attempt originated.
+ * @param {Object} privateProps - The private data of the Lease Manager from which the attempt originated.
  * @param {string} shardId - The ID of the shard to acquire or renew a lease for.
  * @param {Object} shardsDescription - The AWS-provided data describing the shards.
  * @fulfil {boolean} - `true` if a change in the leases was detected, `false` otherwise.
  * @returns {Promise}
  */
-async function acquireLease(instance, shardId, shardsDescription) {
-  const privateProps = internal(instance);
+async function acquireLease(privateProps, shardId, shardsDescription) {
   const { consumerId, isStandalone, logger, stateStore } = privateProps;
 
   // Retrieve the state of the shard and the stream.
@@ -151,6 +137,8 @@ async function acquireLease(instance, shardId, shardsDescription) {
  * @alias module:lease-manager
  */
 class LeaseManager {
+  #data = {};
+
   /**
    * Initializes an instance of the lease manager.
    *
@@ -184,7 +172,7 @@ class LeaseManager {
       useEnhancedFanOut
     } = options;
 
-    Object.assign(internal(this), {
+    Object.assign(this.#data, {
       client,
       consumerId,
       consumersManager,
@@ -205,7 +193,7 @@ class LeaseManager {
    * @returns {Promise}
    */
   async start() {
-    const privateProps = internal(this);
+    const privateProps = this.#data;
     const {
       consumersManager,
       leaseAcquisitionInterval = ACQUIRE_LEASES_INTERVAL,
@@ -247,7 +235,7 @@ class LeaseManager {
           await Object.keys(shards).reduce(async (result, id) => {
             const acc = await result;
             try {
-              return acc.concat(await acquireLease(this, id, shards));
+              return acc.concat(await acquireLease(privateProps, id, shards));
             } catch (err) {
               logger.error('Unexpected recoverable failure when trying to acquire a lease:', err);
               nextDelay = leaseAcquisitionRecoveryInterval;
@@ -276,7 +264,7 @@ class LeaseManager {
    * Stops the lease manager attempts to acquire leases for the shards.
    */
   stop() {
-    const privateProps = internal(this);
+    const privateProps = this.#data;
     const { logger, timeoutId } = privateProps;
     clearTimeout(timeoutId);
     privateProps.timeoutId = null;

--- a/lib/polling-consumer.js
+++ b/lib/polling-consumer.js
@@ -11,20 +11,6 @@ const deaggregate = require('./deaggregate');
 const { getRecordsDecoder } = require('./records');
 const { getStreamShards } = require('./stream');
 
-const privateData = new WeakMap();
-
-/**
- * Provides access to the private data of the specified instance.
- *
- * @param {Object} instance - The private data's owner.
- * @returns {Object} The private data.
- * @private
- */
-function internal(instance) {
-  if (!privateData.has(instance)) privateData.set(instance, {});
-  return privateData.get(instance);
-}
-
 /**
  * Requests an new shard iterator form the given stream and shard. If a sequence number is
  * provided the iterator points to the next record after the sequence number, if not provided,
@@ -73,12 +59,12 @@ async function getShardIterator(
  * Polls for records and pushes them to the parent stream. If auto-checkpoints are enabled, they
  * will be stored before the request for records.
  *
- * @param {Object} instance - The instance for which the private data will be retrieved for.
+ * @param {Object} props - The private data of the consumer instance.
  * @returns {Promise}
  * @private
  */
-async function pollForRecords(instance) {
-  const privateProps = internal(instance);
+async function pollForRecords(props) {
+  const privateProps = props;
 
   const {
     approxArrival,
@@ -163,7 +149,7 @@ async function pollForRecords(instance) {
 
       const delay = msBehind <= 0 ? noRecordsPollDelay : 0;
       if (delay === 0) logger.debug(`Fast-forwarding "${shardId}"… (${msBehind}ms behind)`);
-      privateProps.timeoutId = setTimeout(pollForRecords, delay, instance);
+      privateProps.timeoutId = setTimeout(pollForRecords, delay, privateProps);
       return;
     }
 
@@ -194,14 +180,14 @@ async function pollForRecords(instance) {
     pushToStream(null, propsToPush);
 
     if (!usePausedPolling) {
-      privateProps.timeoutId = setTimeout(pollForRecords, pollDelay, instance);
+      privateProps.timeoutId = setTimeout(pollForRecords, pollDelay, privateProps);
     }
   } catch (err) {
     if (privateProps.stopped) return;
     if (err.code === 'ExpiredIteratorException') {
       logger.warn('Previous shard iterator expired, recreating…');
       privateProps.iterator = null;
-      await pollForRecords(instance);
+      await pollForRecords(privateProps);
       return;
     }
     logger.error(err);
@@ -215,6 +201,8 @@ async function pollForRecords(instance) {
  * @alias module:polling-consumer
  */
 class PollingConsumer {
+  #data = {};
+
   /**
    * Initializes an instance of the polling consumer.
    *
@@ -268,7 +256,7 @@ class PollingConsumer {
       useS3ForLargeItems
     } = options;
 
-    Object.assign(internal(this), {
+    Object.assign(this.#data, {
       approxArrival: null,
       checkpoint,
       client,
@@ -313,7 +301,7 @@ class PollingConsumer {
    * @returns {Promise}
    */
   async start() {
-    const privateProps = internal(this);
+    const privateProps = this.#data;
     const { logger, shardId, stateStore, stopConsumer } = privateProps;
 
     let shardsPath;
@@ -339,16 +327,16 @@ class PollingConsumer {
       privateProps.approxArrival = approxArrival;
     };
 
-    privateProps.continuePolling = () => pollForRecords(this);
+    privateProps.continuePolling = () => pollForRecords(privateProps);
 
-    pollForRecords(this);
+    pollForRecords(privateProps);
   }
 
   /**
    * Stops the consumer from polling for more records.
    */
   stop() {
-    const privateProps = internal(this);
+    const privateProps = this.#data;
     clearTimeout(privateProps.timeoutId);
     privateProps.timeoutId = null;
     privateProps.stopped = true;
@@ -360,7 +348,7 @@ class PollingConsumer {
    * @param {string} leaseExpiration - The updated timestamp when the shard lease expires.
    */
   updateLeaseExpiration(leaseExpiration) {
-    internal(this).leaseExpiration = new Date(leaseExpiration).getTime();
+    this.#data.leaseExpiration = new Date(leaseExpiration).getTime();
   }
 }
 

--- a/lib/records.js
+++ b/lib/records.js
@@ -15,20 +15,6 @@ const compressionLibs = require('./compression');
 
 const IS_JSON_REGEX = /^[[{].*[\]}]$/;
 
-const privateData = new WeakMap();
-
-/**
- * Provides access to the private data of the specified instance.
- *
- * @param {Object} instance - The private data's owner.
- * @returns {Object} The private data.
- * @private
- */
-function internal(instance) {
-  if (!privateData.has(instance)) privateData.set(instance, {});
-  return privateData.get(instance);
-}
-
 /**
  * Hashes the given buffer into a SHA1-Base64 string.
  *
@@ -194,6 +180,8 @@ function getRecordsEncoder({
  * @see https://nodejs.org/dist/latest-v10.x/docs/api/stream.html#stream_class_stream_transform
  */
 class RecordsDecoder extends Transform {
+  #data = {};
+
   /**
    * Initializes the decoder stream.
    *
@@ -207,7 +195,7 @@ class RecordsDecoder extends Transform {
   constructor({ compression, logger, s3Client, shouldParseJson, useS3ForLargeItems }) {
     super({ objectMode: true });
 
-    Object.assign(internal(this), {
+    Object.assign(this.#data, {
       compression,
       recordsDecoder: getRecordsDecoder({
         compression,
@@ -231,7 +219,7 @@ class RecordsDecoder extends Transform {
    * @returns {void}
    */
   _transform({ headers, payload }, encoding, callback) {
-    const { recordsDecoder } = internal(this);
+    const { recordsDecoder } = this.#data;
     const msgType = headers[':message-type'];
     const eventType = headers[':event-type'];
 

--- a/lib/s3-client.js
+++ b/lib/s3-client.js
@@ -16,20 +16,7 @@ const { S3 } = require('aws-sdk');
 const { reportError, reportResponse } = require('./stats');
 const { getStackObj, shouldBailRetry, transformErrorStack } = require('./utils');
 
-const privateData = new WeakMap();
 const statsSource = 's3';
-
-/**
- * Provides access to the private data of the specified instance.
- *
- * @param {Object} instance - The private data's owner.
- * @returns {Object} The private data.
- * @private
- */
-function internal(instance) {
-  if (!privateData.has(instance)) privateData.set(instance, {});
-  return privateData.get(instance);
-}
 
 /**
  * Calls a method on the given instance of AWS.S3. The call is promisified, the call stack
@@ -110,6 +97,8 @@ function retriableSdkCall(client, methodName, retryOpts, ...args) {
  * @alias module:s3-client
  */
 class S3Client {
+  #data = {};
+
   /**
    * Initializes the AWS.S3 internal instance and prepares the retry logic.
    *
@@ -144,7 +133,7 @@ class S3Client {
       randomize: true
     };
 
-    Object.assign(internal(this), {
+    Object.assign(this.#data, {
       bucketName,
       client,
       largeItemThreshold,
@@ -161,7 +150,7 @@ class S3Client {
    * @returns {Promise}
    */
   createBucket(...args) {
-    const { client } = internal(this);
+    const { client } = this.#data;
     return sdkCall(client, 'createBucket', ...args);
   }
 
@@ -172,7 +161,7 @@ class S3Client {
    * @returns {Promise}
    */
   getBucketLifecycleConfiguration(...args) {
-    const { client, retryOpts } = internal(this);
+    const { client, retryOpts } = this.#data;
     return retriableSdkCall(client, 'getBucketLifecycleConfiguration', retryOpts, ...args).catch(
       (err) => {
         if (err.code === 'NoSuchLifecycleConfiguration') return { Rules: [] };
@@ -188,7 +177,7 @@ class S3Client {
    * @returns {Promise}
    */
   getBucketTagging(...args) {
-    const { client, retryOpts } = internal(this);
+    const { client, retryOpts } = this.#data;
     return retriableSdkCall(client, 'getBucketTagging', retryOpts, ...args).catch((err) => {
       if (err.code === 'NoSuchTagSet') return { TagSet: [] };
       throw err;
@@ -202,7 +191,7 @@ class S3Client {
    * @returns {Promise}
    */
   getObject(...args) {
-    const { client, retryOpts } = internal(this);
+    const { client, retryOpts } = this.#data;
     return retriableSdkCall(client, 'getObject', retryOpts, ...args);
   }
 
@@ -213,7 +202,7 @@ class S3Client {
    * @returns {Promise}
    */
   headBucket(...args) {
-    const { client, retryOpts } = internal(this);
+    const { client, retryOpts } = this.#data;
     return retriableSdkCall(client, 'headBucket', retryOpts, ...args);
   }
 
@@ -224,7 +213,7 @@ class S3Client {
    * @returns {Promise}
    */
   putBucketLifecycleConfiguration(...args) {
-    const { client, retryOpts } = internal(this);
+    const { client, retryOpts } = this.#data;
     return retriableSdkCall(client, 'putBucketLifecycleConfiguration', retryOpts, ...args);
   }
 
@@ -235,7 +224,7 @@ class S3Client {
    * @returns {Promise}
    */
   putBucketTagging(...args) {
-    const { client, retryOpts } = internal(this);
+    const { client, retryOpts } = this.#data;
     return retriableSdkCall(client, 'putBucketTagging', retryOpts, ...args);
   }
 
@@ -246,7 +235,7 @@ class S3Client {
    * @returns {Promise}
    */
   putObject(...args) {
-    const { client, retryOpts } = internal(this);
+    const { client, retryOpts } = this.#data;
     return retriableSdkCall(client, 'putObject', retryOpts, ...args);
   }
 }

--- a/lib/state-store.js
+++ b/lib/state-store.js
@@ -17,30 +17,16 @@ const { name: moduleName } = require('../package.json');
 
 const appName = projectName(process.cwd());
 const host = hostname();
-const privateData = new WeakMap();
 const { pid, uptime } = process;
-
-/**
- * Provides access to the private data of the specified instance.
- *
- * @param {Object} instance - The private data's owner.
- * @returns {Object} The private data.
- * @private
- */
-function internal(instance) {
-  if (!privateData.has(instance)) privateData.set(instance, {});
-  return privateData.get(instance);
-}
 
 /**
  * Retrieves the stream state.
  *
- * @param {Object} instance - The instance of the state store to get the private data from.
+ * @param {Object} privateProps - The private data of the state store.
  * @returns {Promise}
  * @private
  */
-async function getStreamState(instance) {
-  const privateProps = internal(instance);
+async function getStreamState(privateProps) {
   const { client, consumerGroup, streamName } = privateProps;
   const { Item } = await client.get({
     ConsistentRead: true,
@@ -52,12 +38,11 @@ async function getStreamState(instance) {
 /**
  * Ensures there's an entry for the current stream in the state database.
  *
- * @param {Object} instance - The instance of the state store to get the private data from.
+ * @param {Object} privateProps - The private data of the state store.
  * @returns {Promise}
  * @private
  */
-async function initStreamState(instance) {
-  const privateProps = internal(instance);
+async function initStreamState(privateProps) {
   const { client, consumerGroup, logger, streamCreatedOn, streamName } = privateProps;
 
   const Key = { consumerGroup, streamName };
@@ -94,13 +79,13 @@ async function initStreamState(instance) {
  * enhanced fan-out but is unable to use one of the registered enhanced consumers. When non
  * active, a consumer isn't used when calculating the maximum active number of leases.
  *
- * @param {Object} instance - The instance of the state store to get the private data from.
+ * @param {Object} privateProps - The private data of the state store.
  * @param {boolean} isActive - The value to set the "is active" flag to.
  * @fulfil {undefined}
  * @returns {Promise}
  */
-async function updateConsumerIsActive(instance, isActive) {
-  const { client, consumerGroup, consumerId, logger, streamName } = internal(instance);
+async function updateConsumerIsActive(privateProps, isActive) {
+  const { client, consumerGroup, consumerId, logger, streamName } = privateProps;
   try {
     await client.update({
       ExpressionAttributeNames: {
@@ -122,15 +107,15 @@ async function updateConsumerIsActive(instance, isActive) {
 /**
  * Tries to lock an enhanced fan-out consumer to this consumer.
  *
- * @param {Object} instance - The instance of the state store to get the private data from.
+ * @param {Object} privateProps - The private data of the state store.
  * @param {string} consumerName - The name of the enhanced fan-out consumer to lock.
  * @param {string} version - The known version  number of the enhanced consumer state entry.
  * @fulfil {boolean} - `true` if the enhanced consumer was locked, `false` otherwise.
  * @returns {Promise}
  */
-async function lockEnhancedConsumer(instance, consumerName, version) {
+async function lockEnhancedConsumer(privateProps, consumerName, version) {
   const { client, consumerGroup, consumerId, logger, streamName, useAutoShardAssignment } =
-    internal(instance);
+    privateProps;
 
   try {
     await client.update({
@@ -170,6 +155,8 @@ async function lockEnhancedConsumer(instance, consumerName, version) {
  * @alias module:state-store
  */
 class StateStore {
+  #data = {};
+
   /**
    * Initializes an instance of the state store.
    *
@@ -207,7 +194,7 @@ class StateStore {
       useEnhancedFanOut
     } = options;
 
-    Object.assign(internal(this), {
+    Object.assign(this.#data, {
       awsOptions,
       consumerGroup,
       consumerId,
@@ -234,10 +221,10 @@ class StateStore {
    * @returns {Promise}
    */
   async clearOldConsumers(heartbeatFailureTimeout) {
-    const privateProps = internal(this);
+    const privateProps = this.#data;
     const { client, consumerGroup, logger, streamName } = privateProps;
 
-    const { consumers, enhancedConsumers, version } = await getStreamState(this);
+    const { consumers, enhancedConsumers, version } = await getStreamState(this.#data);
     const consumerIds = Object.keys(consumers);
 
     const oldConsumers = consumerIds.filter((id) => {
@@ -329,7 +316,7 @@ class StateStore {
    * @returns {Promise}
    */
   async deregisterEnhancedConsumer(name) {
-    const { client, consumerGroup, logger, streamName } = internal(this);
+    const { client, consumerGroup, logger, streamName } = this.#data;
 
     try {
       await client.update({
@@ -360,7 +347,7 @@ class StateStore {
    * @returns {Promise}
    */
   async ensureShardStateExists(shardId, shardData, streamState) {
-    const privateProps = internal(this);
+    const privateProps = this.#data;
     const { shardsPath, shardsPathNames } = await this.getShardsData(streamState);
     const { client, consumerGroup, logger, streamName } = privateProps;
     const { parent } = shardData;
@@ -398,7 +385,7 @@ class StateStore {
    * @returns {Promise}
    */
   async getAssignedEnhancedConsumer() {
-    const { consumerId, logger } = internal(this);
+    const { consumerId, logger } = this.#data;
 
     let consumerArn;
     let consumerName;
@@ -423,7 +410,7 @@ class StateStore {
       for (let i = 0; i < availableConsumers.length; i += 1) {
         const name = availableConsumers[i];
         const { arn, version } = enhancedConsumers[name];
-        if (await lockEnhancedConsumer(this, name, version)) {
+        if (await lockEnhancedConsumer(this.#data, name, version)) {
           consumerArn = arn;
           consumerName = name;
           break;
@@ -433,11 +420,11 @@ class StateStore {
 
     if (!consumerArn) {
       logger.warn(`All enhanced fan-out consumers are assigned. Waiting until one is available…`);
-      await updateConsumerIsActive(this, false);
+      await updateConsumerIsActive(this.#data, false);
       return null;
     }
 
-    await updateConsumerIsActive(this, true);
+    await updateConsumerIsActive(this.#data, true);
     logger.debug(`Using the "${consumerName}" enhanced fan-out consumer.`);
     return consumerArn;
   }
@@ -449,7 +436,7 @@ class StateStore {
    * @returns {Promise}
    */
   async getEnhancedConsumers() {
-    const { enhancedConsumers } = await getStreamState(this);
+    const { enhancedConsumers } = await getStreamState(this.#data);
     return enhancedConsumers;
   }
 
@@ -460,8 +447,8 @@ class StateStore {
    * @returns {Promise}
    */
   async getOwnedShards() {
-    const { consumerId } = internal(this);
-    const streamState = await getStreamState(this);
+    const { consumerId } = this.#data;
+    const streamState = await getStreamState(this.#data);
     const { shards } = await this.getShardsData(streamState);
 
     return Object.keys(shards)
@@ -485,7 +472,7 @@ class StateStore {
    */
   async getShardAndStreamState(shardId, shardData) {
     const getState = async () => {
-      const streamState = await getStreamState(this);
+      const streamState = await getStreamState(this.#data);
       const { shards } = await this.getShardsData(streamState);
       const shardState = shards[shardId];
       return { shardState, streamState };
@@ -517,8 +504,8 @@ class StateStore {
    * @returns {Promise}
    */
   async getShardsData(streamState) {
-    const { consumerId, useAutoShardAssignment, useEnhancedFanOut } = internal(this);
-    const normStreamState = !streamState ? await getStreamState(this) : streamState;
+    const { consumerId, useAutoShardAssignment, useEnhancedFanOut } = this.#data;
+    const normStreamState = !streamState ? await getStreamState(this.#data) : streamState;
     const { consumers, enhancedConsumers } = normStreamState;
 
     if (!useAutoShardAssignment) {
@@ -572,7 +559,7 @@ class StateStore {
    * @returns {Promise}
    */
   async lockShardLease(shardId, leaseTermTimeout, version, streamState) {
-    const { client, consumerGroup, consumerId, logger, streamName } = internal(this);
+    const { client, consumerGroup, consumerId, logger, streamName } = this.#data;
     const { shardsPath, shardsPathNames } = await this.getShardsData(streamState);
     try {
       await client.update({
@@ -616,9 +603,9 @@ class StateStore {
    * @returns {Promise}
    */
   async markShardAsDepleted(shardsData, parentShardId) {
-    const { client, consumerGroup, streamName } = internal(this);
+    const { client, consumerGroup, streamName } = this.#data;
 
-    const streamState = await getStreamState(this);
+    const streamState = await getStreamState(this.#data);
     const { shards, shardsPath, shardsPathNames } = await this.getShardsData(streamState);
     const parentShard = shards[parentShardId];
 
@@ -695,7 +682,7 @@ class StateStore {
       streamName,
       useAutoShardAssignment,
       useEnhancedFanOut
-    } = internal(this);
+    } = this.#data;
 
     try {
       await client.update({
@@ -754,7 +741,7 @@ class StateStore {
    * @returns {Promise}
    */
   async registerEnhancedConsumer(name, arn) {
-    const { client, consumerGroup, logger, streamName, useAutoShardAssignment } = internal(this);
+    const { client, consumerGroup, logger, streamName, useAutoShardAssignment } = this.#data;
 
     try {
       await client.update({
@@ -794,7 +781,7 @@ class StateStore {
    * @returns {Promise}
    */
   async releaseShardLease(shardId, version, streamState) {
-    const privateProps = internal(this);
+    const privateProps = this.#data;
     const { client, consumerGroup, logger, streamName } = privateProps;
     const { shardsPath, shardsPathNames } = await this.getShardsData(streamState);
     const releasedVersion = generate();
@@ -841,7 +828,7 @@ class StateStore {
    * @returns {Promise}
    */
   async start() {
-    const privateProps = internal(this);
+    const privateProps = this.#data;
     const { tags } = privateProps;
 
     const client = new DynamoDbClient(privateProps);
@@ -849,7 +836,7 @@ class StateStore {
 
     privateProps.tableArn = await ensureTableExists(privateProps);
     if (tags) await confirmTableTags(privateProps);
-    await initStreamState(this);
+    await initStreamState(this.#data);
   }
 
   /**
@@ -859,7 +846,7 @@ class StateStore {
    * @returns {undefined}
    */
   stop() {
-    const { client } = internal(this);
+    const { client } = this.#data;
     client.stop();
   }
 
@@ -881,7 +868,7 @@ class StateStore {
     shardsPathNames,
     approximateArrivalTimestamp
   ) {
-    const privateProps = internal(this);
+    const privateProps = this.#data;
     const { logger } = privateProps;
     if (typeof checkpoint !== 'string') throw new TypeError('The sequence number is required.');
     let approximateArrivalTimestampString = null;
@@ -897,7 +884,7 @@ class StateStore {
       logger.warn('Will ignore approx arrival timestamp provided, it was null');
     }
 
-    const { client, consumerGroup, streamName } = internal(this);
+    const { client, consumerGroup, streamName } = this.#data;
 
     try {
       await client.update({


### PR DESCRIPTION
## What

Replaces the WeakMap private-data hack with native `#data` class fields across all 11 `lib` classes. This is step 3 of the v2 modernization (after the Node 22 floor in #762), and the move is what the native-private-fields support of the new floor unlocks.

Each class used to keep per-instance state in a module-level `const privateData = new WeakMap()` reached through an `internal(instance)` helper. That pattern predates `#private` fields. Now each class holds one `#data` field and reads `this.#data` directly.

## Design note: one `#data` bag, not per-property fields

`index.js` and `state-store.js` pass the whole private object to free helper functions (`ensureStreamExists(props)`, `getStreamState(props)`, and so on). Only a plain object can be passed that way, so a single `#data` object preserves that structure with a near-mechanical diff. Per-property fields (`this.#client`, `this.#streamName`, ...) would have meant unwinding those helpers, which is out of scope here.

## Reviewer heads-up: the `const x = props` lines

`no-param-reassign` (with `props: true`) forbids a free function from mutating a bag passed as a parameter. The two helpers that assign to its properties, `pollForRecords` and `ensureStreamInitialized`, alias the parameter to a local first (`const privateProps = props`) so the mutations land on a local, not the param. Read-only and `Object.assign`-only helpers needed no alias.

## Verification

- 438 jest tests pass, 100% coverage held
- `eslint` clean (0 errors; the 3 warnings are the pre-existing baseline)
- smoke test passes (clean `require()` exit, no MessagePort regression)
- generated README byte-identical (no public JSDoc changed)
- net −126 lines

No public API or runtime behavior change.

Part of #727.
