### PR TITLE
build: activate jsdoc tag-lines and reject-function-type rules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -64,11 +64,10 @@ export default defineConfig([
       'jsdoc/no-defaults': 'off',
       'jsdoc/no-undefined-types': ['error', { definedTypes: ['NodeJS'] }],
       'jsdoc/reject-any-type': 'off',
-      'jsdoc/reject-function-type': 'off',
       'jsdoc/require-hyphen-before-param-description': 'warn',
       'jsdoc/require-jsdoc': 'off',
       'jsdoc/require-returns-description': 'off',
-      'jsdoc/tag-lines': 'off',
+      'jsdoc/tag-lines': ['warn', 'never', { startLines: 1 }],
       'n/handle-callback-err': 'off',
       'n/no-missing-import': 'error',
       'no-secrets/no-secrets': [

--- a/lib/consumers-manager.js
+++ b/lib/consumers-manager.js
@@ -31,7 +31,7 @@ class ConsumersManager {
    *        get more records when there were none in the previous attempt.
    * @param {number} options.pollDelay - When the `usePausedPolling` option is `false`, this
    *        option defines the delay in milliseconds in between poll requests for more records.
-   * @param {Function} options.pushToStream - A function to push incoming records to the consumer.
+   * @param {function(Error, Object): void} options.pushToStream - A function to push incoming records to the consumer.
    * @param {Object} options.s3 - The S3 options in the current kinesis client.
    * @param {string|boolean} [options.shouldParseJson] - Whether if retrieved records' data should
    *        be parsed as JSON or not.

--- a/lib/deaggregate.js
+++ b/lib/deaggregate.js
@@ -19,8 +19,8 @@ const builder = ProtoBuf.Root.fromJSON(aggJson).lookupType(MESSAGE_NAME);
  * asynchronous deaggregation interface
  *
  * @param {Object} kinesisRecord - The kinesis message
- * @param {Function} perRecordCallback - A callback invoked for each deaggregated record
- * @param {Function} afterRecordCallback - A callback invoked after all records have been deaggregated
+ * @param {function(Error, Object): void} perRecordCallback - A callback invoked for each deaggregated record
+ * @param {function(): void} afterRecordCallback - A callback invoked after all records have been deaggregated
  */
 const deaggregate = (kinesisRecord, perRecordCallback, afterRecordCallback) => {
   // we receive the record data as a base64 encoded string

--- a/lib/fan-out-consumer.js
+++ b/lib/fan-out-consumer.js
@@ -59,7 +59,7 @@ class Deaggregate extends Transform {
    *
    * @param {Buffer} chunk - A chunk of data coming from the event stream.
    * @param {string} encoding - The stream encoding mode (ignored)
-   * @param {Function} callback - The callback for more data.
+   * @param {function(Error=): void} callback - The callback for more data.
    */
   async _transform(chunk, encoding, callback) {
     const { logger } = this.#data;
@@ -119,7 +119,7 @@ class PreProcess extends Transform {
    *
    * @param {Buffer} chunk - A chunk of data coming from the event stream.
    * @param {string} encoding - The stream encoding mode (ignored)
-   * @param {Function} callback - The callback for more data.
+   * @param {function(Error=): void} callback - The callback for more data.
    */
   _transform(chunk, encoding, callback) {
     const { requestFlags } = this.#data;
@@ -164,13 +164,13 @@ class PostProcess extends Writable {
    * Initializes an instance of the post-processing stream.
    *
    * @param {Object} options - The initialization options.
-   * @param {Function} options.abort - A function that will close the entire pipeline, called
+   * @param {function(): void} options.abort - A function that will close the entire pipeline, called
    *        when no data has been pushed through the event stream on a given time window.
    * @param {Object} options.logger - An instance of a logger.
-   * @param {Function} options.markShardAsDepleted - A function that will mark a given shard as
+   * @param {function(): void} options.markShardAsDepleted - A function that will mark a given shard as
    *        depleted. Called when a shard depletion event has been detected.
-   * @param {Function} options.pushToStream - A function that pushes records out of the pipeline.
-   * @param {Function} options.setCheckpoint - A function that stores the checkpoint for the shard.
+   * @param {function(Error, Object): void} options.pushToStream - A function that pushes records out of the pipeline.
+   * @param {function(string): Promise<void>} options.setCheckpoint - A function that stores the checkpoint for the shard.
    * @param {string} options.shardId - The ID of the shard.
    */
   constructor({ abort, logger, markShardAsDepleted, pushToStream, setCheckpoint, shardId }) {
@@ -196,7 +196,7 @@ class PostProcess extends Writable {
    *
    * @param {Object} chunk - A chunk of data coming from the pipeline.
    * @param {string} encoding - The stream encoding mode (ignored)
-   * @param {Function} callback - The callback for more data.
+   * @param {function(Error=): void} callback - The callback for more data.
    */
   async _write(chunk, encoding, callback) {
     const { abort, logger, markShardAsDepleted, pushToStream, setCheckpoint, shardId, timeoutId } =
@@ -240,10 +240,10 @@ class FanOutConsumer {
    *        fetching records from when the application starts for the first time and there is no checkpoint for the shard.
    * @param {string} options.leaseExpiration - The timestamp of the shard lease expiration.
    * @param {Object} options.logger - An instance of a logger.
-   * @param {Function} options.pushToStream - A function to push incoming records to the consumer.
+   * @param {function(Error, Object): void} options.pushToStream - A function to push incoming records to the consumer.
    * @param {string} options.shardId - The ID of the stream shard to subscribe for records.
    * @param {Object} options.stateStore - An instance of the state store.
-   * @param {Function} options.stopConsumer - A function that stops this consumer from the manager.
+   * @param {function(): void} options.stopConsumer - A function that stops this consumer from the manager.
    * @param {string} options.streamName - The name of the Kinesis stream.
    *        user-intervention before polling for more records, or not.
    * @param {boolean} options.useS3ForLargeItems - Whether to automatically use an S3

--- a/lib/polling-consumer.js
+++ b/lib/polling-consumer.js
@@ -217,10 +217,10 @@ class PollingConsumer {
    *        get more records when there were none in the previous attempt.
    * @param {number} options.pollDelay - When the `usePausedPolling` option is `false`, this
    *        option defines the delay in milliseconds in between poll requests for more records.
-   * @param {Function} options.pushToStream - A function to push incoming records to the consumer.
+   * @param {function(Error, Object): void} options.pushToStream - A function to push incoming records to the consumer.
    * @param {string} options.shardId - The ID of the stream shard to retrieve records for.
    * @param {Object} options.stateStore - An instance of the state store.
-   * @param {Function} options.stopConsumer - A function that stops this consumer from the manager.
+   * @param {function(): void} options.stopConsumer - A function that stops this consumer from the manager.
    * @param {string} options.streamName - The name of the Kinesis stream.
    * @param {boolean} options.useAutoCheckpoints - Whether to automatically store shard checkpoints
    *        using the sequence number of the most-recently received record or not.

--- a/lib/records.js
+++ b/lib/records.js
@@ -35,7 +35,7 @@ function hash(buffer) {
  * @param {Object} [options.logger] - An instance of a logger.
  * @param {Object} [options.s3Client] - The s3Client in the current kinesis client.
  * @param {boolean} [options.useS3ForLargeItems] - Whether to automatically use an S3 bucket to store large items or not.
- * @returns {Function} A function that decodes `record` objects from AWS.Kinesis.
+ * @returns {function(Object): Promise<Object>} A function that decodes `record` objects from AWS.Kinesis.
  * @memberof module:records
  */
 function getRecordsDecoder({
@@ -112,7 +112,7 @@ function getRecordsDecoder({
  * @param {Object} [options.s3Client] - The s3Client in the current kinesis client.
  * @param {Object} [options.streamName] - The name of the kinesis stream.
  * @param {boolean} [options.useS3ForLargeItems] - Whether to automatically use an S3 bucket to store large items or not.
- * @returns {Function} A function that encodes objects into the format expected by AWS.Kinesis.
+ * @returns {function(Object): Promise<Object>} A function that encodes objects into the format expected by AWS.Kinesis.
  * @memberof module:records
  */
 function getRecordsEncoder({
@@ -213,7 +213,7 @@ class RecordsDecoder extends Transform {
    * @param {Object} chunk.headers - The headers from an AWS event stream chunk.
    * @param {Object} chunk.payload - The payload from an AWS event stream chunk.
    * @param {string} encoding - The encoding used in the stream (ignored)
-   * @param {Function} callback - The callback to signal for completion.
+   * @param {function(Error=): void} callback - The callback to signal for completion.
    * @returns {void}
    */
   _transform({ headers, payload }, encoding, callback) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -53,7 +53,7 @@ function transformErrorStack(err, stackObj) {
  * variable is defined. The returned object is used in conjuntion with `transformErrorStack` to
  * modify the stack of asynchronous errors thrown by the AWS SDK.
  *
- * @param {Function} caller - The function or class whose constructor could throw an error.
+ * @param {function(...*): *} caller - The function or class whose constructor could throw an error.
  * @returns {Object} An object with a captured stack trace (if enabled).
  * @memberof module:utils
  */


### PR DESCRIPTION
## Summary

Follow-up to #772: turn on two jsdoc rules that were disabled during the ESLint 9 migration (to keep the generated README untouched), now that we've confirmed they don't degrade the API docs.

- **`tag-lines`** (with `startLines: 1`) — enforces the existing house style: exactly one blank line between a JSDoc block's description and its first tag, and none between tags. **Zero source churn** (develop already follows this).
- **`reject-function-type`** — replaces the vague `{Function}` type on the 18 internal callbacks with explicit **Closure signatures** (e.g. `function(Error, Object): void`, `function(Object): Promise<Object>`), documenting each callback's actual shape.

## Deliberately left off

- **`reject-any-type`** — the `{*}` types are honestly polymorphic (`params.data` is arbitrary record payload; `@fulfil {*}` is the raw AWS response). Forcing a concrete type would misrepresent them.
- **`no-defaults`** — the `[option=default]` annotations on the public `Kinesis` constructor are useful API documentation; the rule would strip them.

## Notes

- **Closure** type syntax (`function(T): R`) is used rather than TypeScript-style arrows (`(x: T) => R`): ESLint accepts both, but **jsdoc2md only parses Closure** — arrows make it bail and drop the whole README.
- README regen is **byte-identical** (callbacks are `@private`), lint is clean, and the 438 unit tests pass at 100% coverage.