### PR TITLE
build: remove unused chalk devDependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,6 @@
         "@vitest/coverage-v8": "^4.1.8",
         "@vitest/eslint-plugin": "^1.6.19",
         "auto-changelog": "^2.4.0",
-        "chalk": "^4.1.2",
         "chance": "^1.1.8",
         "eslint": "^9.39.4",
         "eslint-config-prettier": "^10.1.8",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
     "@vitest/coverage-v8": "^4.1.8",
     "@vitest/eslint-plugin": "^1.6.19",
     "auto-changelog": "^2.4.0",
-    "chalk": "^4.1.2",
     "chance": "^1.1.8",
     "eslint": "^9.39.4",
     "eslint-config-prettier": "^10.1.8",


### PR DESCRIPTION
chalk was declared as a devDependency but is never imported anywhere in the source, scripts, or config. Removing it rather than bumping to v5.

Supersedes Dependabot PR #771 (chalk 4 → 5), which will be closed.

- `npm test` — 441 tests, 100% coverage
- `npm run eslint` — clean