### PR TITLE
build: bump short-uuid from 4.2.2 to 6.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "lzutf8": "^0.6.3",
         "project-name": "^1.0.0",
         "protobufjs": "^8.5.0",
-        "short-uuid": "^4.2.2"
+        "short-uuid": "^6.0.3"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
@@ -8807,26 +8807,15 @@
       }
     },
     "node_modules/short-uuid": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/short-uuid/-/short-uuid-4.2.2.tgz",
-      "integrity": "sha512-IE7hDSGV2U/VZoCsjctKX6l5t5ak2jE0+aeGJi3KtvjIUNuZVmHVYUjNBhmo369FIWGDtaieRaO8A83Lvwfpqw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/short-uuid/-/short-uuid-6.0.3.tgz",
+      "integrity": "sha512-UMZ3rYOoid307EqWsPTnoBUSOB51Fi28vUMPigUsSCmbaSvslyf/SlXZWOn4btj8tokhBTBkPFKVKKlIolEG1w==",
       "license": "MIT",
       "dependencies": {
-        "any-base": "^1.1.0",
-        "uuid": "^8.3.2"
+        "any-base": "^1.1.0"
       },
       "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/short-uuid/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
+        "node": ">=14.17.0"
       }
     },
     "node_modules/side-channel": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "lzutf8": "^0.6.3",
     "project-name": "^1.0.0",
     "protobufjs": "^8.5.0",
-    "short-uuid": "^4.2.2"
+    "short-uuid": "^6.0.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",


### PR DESCRIPTION
Bumps the `short-uuid` runtime dependency from 4.2.2 to 6.0.3.

v6 keeps the `.generate` API the library uses (`lib/records.js`, `lib/index.js`, `lib/state-store.js`). Confirmed against the real module:

```
import shortUuid from 'short-uuid';
const { generate } = shortUuid; // function, returns a base58 id
```

Supersedes Dependabot PR #766, which will be closed.

- `npm test` — 441 tests, 100% coverage
- `npm run eslint` — clean