### PR TITLE
refactor: extract option normalization from Kinesis constructor

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -37,6 +37,39 @@ const { generate } = shortUuid;
 const MAX_ENHANCED_CONSUMER_PER_CREATION = 5;
 
 /**
+ * Wraps the provided logger so that `debug`, `error`, and `warn` are always callable, falling
+ * back to a no-op for any method the consumer did not provide.
+ *
+ * @param {Object} logger - The logger provided in the constructor options.
+ * @returns {Object} A logger with guaranteed `debug`, `error`, and `warn` methods.
+ * @private
+ */
+function normalizeLogger(logger) {
+  const wrap = (method) =>
+    typeof logger[method] === 'function' ? logger[method].bind(logger) : Function.prototype;
+  return { debug: wrap('debug'), error: wrap('error'), warn: wrap('warn') };
+}
+
+/**
+ * Coerces a value to a number, returning it when it falls within the given bounds or the
+ * fallback otherwise.
+ *
+ * @param {*} value - The value to coerce and validate.
+ * @param {Object} bounds - The validation bounds.
+ * @param {number} bounds.fallback - The value to return when `value` is out of bounds.
+ * @param {number} [bounds.max=Infinity] - The inclusive upper bound.
+ * @param {number} bounds.min - The lower bound.
+ * @param {boolean} [bounds.minInclusive=true] - Whether the lower bound is inclusive.
+ * @returns {number} The validated number or the fallback.
+ * @private
+ */
+function boundedNumber(value, { fallback, max = Infinity, min, minInclusive = true }) {
+  const number = Number(value);
+  const aboveMin = minInclusive ? number >= min : number > min;
+  return aboveMin && number <= max ? number : fallback;
+}
+
+/**
  * Ensures a Kinesis stream exists and that is encrypted and tagged as required.
  *
  * @param {Object} props - The private data of the Kinesis instance.
@@ -311,25 +344,13 @@ class Kinesis extends PassThrough {
       ...awsOptions
     } = options;
 
-    const normLogger = {
-      debug: typeof logger.debug === 'function' ? logger.debug.bind(logger) : Function.prototype,
-      error: typeof logger.error === 'function' ? logger.error.bind(logger) : Function.prototype,
-      warn: typeof logger.warn === 'function' ? logger.warn.bind(logger) : Function.prototype
-    };
+    const normLogger = normalizeLogger(logger);
 
     if (!streamName) {
       const errorMsg = 'The "streamName" option is required.';
       normLogger.error(errorMsg);
       throw new TypeError(errorMsg);
     }
-
-    const limitNumber = Number(limit);
-    const maxConsumersNumber = Number(maxEnhancedConsumers);
-    const noRecordsPollDelayNumber = Number(noRecordsPollDelay);
-    const pollDelayNumber = Number(pollDelay);
-    const shardCountNumber = Number(shardCount);
-    const statsIntervalNumber = Number(statsInterval);
-    const largeItemThresholdNumber = Number(s3.largeItemThreshold || 900);
 
     const s3BucketName = useS3ForLargeItems && (s3.bucketName || streamName);
     const recordsEncoder = useS3ForLargeItems
@@ -367,24 +388,28 @@ class Kinesis extends PassThrough {
         initialPositionInStream === 'TRIM_HORIZON' ? 'TRIM_HORIZON' : 'LATEST',
       leaseAcquisitionInterval,
       leaseAcquisitionRecoveryInterval,
-      limit: limitNumber > 0 && limitNumber <= 10000 ? limitNumber : 10000,
+      limit: boundedNumber(limit, { fallback: 10000, max: 10000, min: 0, minInclusive: false }),
       logger: normLogger,
-      maxEnhancedConsumers:
-        maxConsumersNumber > 0 && maxConsumersNumber <= 20 ? maxConsumersNumber : 5,
-      noRecordsPollDelay: noRecordsPollDelayNumber >= 250 ? noRecordsPollDelayNumber : 250,
-      pollDelay: pollDelayNumber >= 0 ? pollDelayNumber : 250,
+      maxEnhancedConsumers: boundedNumber(maxEnhancedConsumers, {
+        fallback: 5,
+        max: 20,
+        min: 0,
+        minInclusive: false
+      }),
+      noRecordsPollDelay: boundedNumber(noRecordsPollDelay, { fallback: 250, min: 250 }),
+      pollDelay: boundedNumber(pollDelay, { fallback: 250, min: 0 }),
       recordsEncoder,
       s3: {
-        largeItemThreshold: largeItemThresholdNumber,
+        largeItemThreshold: Number(s3.largeItemThreshold || 900),
         nonS3Keys: [],
         ...s3,
         bucketName: s3BucketName
       },
       s3Client: null,
-      shardCount: shardCountNumber >= 1 ? shardCountNumber : 1,
+      shardCount: boundedNumber(shardCount, { fallback: 1, min: 1 }),
       shouldDeaggregate: Boolean(shouldDeaggregate),
       shouldParseJson,
-      statsInterval: statsIntervalNumber >= 1000 ? statsIntervalNumber : 30000,
+      statsInterval: boundedNumber(statsInterval, { fallback: 30000, min: 1000 }),
       streamName,
       tags,
       useAutoCheckpoints: Boolean(useAutoCheckpoints),


### PR DESCRIPTION
CodeFactor flags the `Kinesis` constructor as a Complex Method (cyclomatic complexity 17). The branching came entirely from inline option normalization: three logger ternaries and six numeric-clamp ternaries.

This extracts that logic into two pure module-level helpers:

- `normalizeLogger(logger)` — guarantees callable `debug`/`error`/`warn`, no-op otherwise.
- `boundedNumber(value, { fallback, max, min, minInclusive })` — coerces and bounds-checks a numeric option.

The constructor's real branch count drops to ~7. Behavior is identical (every clamp maps 1:1 to the previous ternary), confirmed by the unit suite at 100% coverage.

- `npm test` — 441 tests, 100% coverage (branches 553/553)
- `npm run eslint` — clean