### PR TITLE
fix: recover stalled shards from fatal polling errors (#332)

### DIFF
--- a/lib/polling-consumer.js
+++ b/lib/polling-consumer.js
@@ -54,6 +54,26 @@ async function getShardIterator(
 }
 
 /**
+ * Releases the lease of the shard so it becomes available for re-acquisition. This allows this or
+ * another consumer to pick the shard up again on the next lease acquisition attempt and resume
+ * polling from the last stored checkpoint, instead of the shard staying silently stalled while its
+ * lease remains owned.
+ *
+ * @param {Object} props - The private data of the consumer instance.
+ * @returns {Promise}
+ * @private
+ */
+async function releaseLease(props) {
+  const { logger, shardId, stateStore } = props;
+  try {
+    const { shardState, streamState } = await stateStore.getShardAndStreamState(shardId, {});
+    await stateStore.releaseShardLease(shardId, shardState.version, streamState);
+  } catch (err) {
+    logger.warn(`Couldn't release the lease for shard "${shardId}":`, err);
+  }
+}
+
+/**
  * Polls for records and pushes them to the parent stream. If auto-checkpoints are enabled, they
  * will be stored before the request for records.
  *
@@ -188,8 +208,12 @@ async function pollForRecords(props) {
       await pollForRecords(privateProps);
       return;
     }
-    logger.error(err);
-    pushToStream(err);
+    logger.warn(
+      `Releasing the lease for shard "${shardId}" to recover from an unexpected error:`,
+      err
+    );
+    await releaseLease(privateProps);
+    stopConsumer(shardId);
   }
 }
 

--- a/lib/polling-consumer.test.js
+++ b/lib/polling-consumer.test.js
@@ -36,9 +36,19 @@ describe('lib/polling-consumer', () => {
   const logger = { debug, error: errorMock, warn };
 
   const getShardsData = vi.fn(() => Promise.resolve({ shardsPath: '', shardsPathNames: {} }));
+  const getShardAndStreamState = vi.fn(() =>
+    Promise.resolve({ shardState: { version: 'shard-version' }, streamState: {} })
+  );
   const markShardAsDepleted = vi.fn();
+  const releaseShardLease = vi.fn(() => Promise.resolve('new-version'));
   const storeShardCheckpoint = vi.fn();
-  const stateStore = { getShardsData, markShardAsDepleted, storeShardCheckpoint };
+  const stateStore = {
+    getShardAndStreamState,
+    getShardsData,
+    markShardAsDepleted,
+    releaseShardLease,
+    storeShardCheckpoint
+  };
 
   const pushToStream = vi.fn();
   const stopConsumer = vi.fn();
@@ -69,8 +79,10 @@ describe('lib/polling-consumer', () => {
     getRecords.mockClear();
     getShardIterator.mockClear();
     getShardsData.mockClear();
+    getShardAndStreamState.mockClear();
     markShardAsDepleted.mockClear();
     pushToStream.mockClear();
+    releaseShardLease.mockClear();
     setTimeout.mockClear();
     stopConsumer.mockClear();
     storeShardCheckpoint.mockClear();
@@ -278,17 +290,39 @@ describe('lib/polling-consumer', () => {
     });
   });
 
-  test('the consumer is able to push errors from internal SDK calls', () => {
+  test('the consumer releases its lease and stops to recover from internal SDK errors', () => {
     const error = new Error('foo');
     getShardIterator.mockRejectedValueOnce(error);
     const consumer = new PollingConsumer(options);
     return new Promise((resolve) => {
-      pushToStream.mockImplementationOnce((err) => {
-        expect(err).toBe(error);
-        expect(debug.mock.calls).toEqual([
-          ['Starting to read shard "shardId-0000" from the latest record.']
-        ]);
-        expect(errorMock.mock.calls).toEqual([[error]]);
+      stopConsumer.mockImplementationOnce((shardId) => {
+        expect(shardId).toBe('shardId-0000');
+        expect(warn).toHaveBeenCalledWith(
+          'Releasing the lease for shard "shardId-0000" to recover from an unexpected error:',
+          error
+        );
+        expect(releaseShardLease).toHaveBeenCalledWith('shardId-0000', 'shard-version', {});
+        expect(pushToStream).not.toHaveBeenCalled();
+        resolve();
+      });
+      consumer.start();
+    }).finally(() => {
+      consumer.stop();
+    });
+  });
+
+  test('the consumer stops even if releasing its lease fails after an SDK error', () => {
+    getShardIterator.mockRejectedValueOnce(new Error('foo'));
+    getShardAndStreamState.mockRejectedValueOnce(new Error('state is gone'));
+    const consumer = new PollingConsumer(options);
+    return new Promise((resolve) => {
+      stopConsumer.mockImplementationOnce((shardId) => {
+        expect(shardId).toBe('shardId-0000');
+        expect(warn).toHaveBeenCalledWith(
+          'Couldn\'t release the lease for shard "shardId-0000":',
+          expect.objectContaining({ message: 'state is gone' })
+        );
+        expect(releaseShardLease).not.toHaveBeenCalled();
         resolve();
       });
       consumer.start();


### PR DESCRIPTION
Fixes #332.

## Problem

A non-retriable `GetRecords`/`GetShardIterator` error in the polling loop emitted the error and stopped rescheduling, while the lease manager kept renewing the shard's lease and the consumers manager never restarted the consumer. The shard silently stalled while still owned and undepleted — matching the DynamoDB state in the report — and only restarting the process recovered it.

## Fix

On a fatal read error, release the shard lease and stop the consumer, so the next lease-acquisition cycle (this instance or another) re-acquires the shard and resumes from the stored checkpoint.

## Note

Fatal polling read errors no longer surface as stream `error` events; they log a warning and self-heal. This is a behavioral change, suitable for v2.

## Tests

Two new unit tests in `polling-consumer.test.js`; full suite 443/443 at 100% coverage.