### PR TITLE
fix: guard stopConsumer against shards cleared by a rebalance (#781)

### DIFF
--- a/lib/consumers-manager.js
+++ b/lib/consumers-manager.js
@@ -230,7 +230,10 @@ class ConsumersManager {
    */
   stop() {
     const { consumers } = this.#data;
-    Object.keys(consumers).forEach((shardId) => consumers[shardId].stop());
+    Object.keys(consumers).forEach((shardId) => {
+      const consumer = consumers[shardId];
+      if (consumer) consumer.stop();
+    });
   }
 }
 

--- a/lib/consumers-manager.test.js
+++ b/lib/consumers-manager.test.js
@@ -204,4 +204,12 @@ describe('lib/consumers-manager', () => {
     manager.stop();
     expect(PollingConsumer.getMocks().stop).toHaveBeenCalled();
   });
+
+  test('stopping ignores shard slots already cleared by a hand-off', async () => {
+    manager = new ConsumersManager({ logger, stateStore });
+    await manager.reconcile();
+    ownedShards = {};
+    await manager.reconcile();
+    expect(() => manager.stop()).not.toThrow();
+  });
 });


### PR DESCRIPTION
Fixes #781.

## Problem

When a shard lease is handed off, the consumers manager clears the shard's slot by setting `consumers[shardId] = undefined` while keeping the key. `ConsumersManager.stop()` iterated every key and called `.stop()` unguarded, so `stopConsumer()` threw `TypeError: Cannot read properties of undefined (reading 'stop')` on any client that had rebalanced (for example after scaling from one consumer to two).

## Fix

Skip cleared slots when stopping.

## How it surfaced

Found while building a LocalStack repro for #652: a 1→2 scale-up handoff completed with zero data loss, but the run crashed on shutdown via this path.

## Tests

One regression test; full suite 443/443 at 100% coverage.