### PR TITLE
docs: add v2 migration guide

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,80 @@
+# Migrating to v2
+
+v2 raises the Node version, swaps in the AWS SDK v3, and ships as an ES module. The public API is the same as v1, so most of the upgrade comes down to the Node version you run and how you import the client.
+
+## Node.js 22.12 or newer
+
+v2 requires Node.js `>=22.12.0`. Older versions are no longer supported. If you can't move off an older Node yet, stay on v1 until you can.
+
+## ESM-only package
+
+v2 ships as an ES module. How you load it depends on your project.
+
+From an ES module, use a default import:
+
+```js
+import Kinesis from 'lifion-kinesis';
+```
+
+From CommonJS, `require` still works on Node 22.12+, but it hands back the module namespace, so reach for the default export:
+
+```js
+const { default: Kinesis } = require('lifion-kinesis');
+```
+
+A bare `const Kinesis = require('lifion-kinesis')` (the v1 style) now gives you the namespace object instead of the class, and `new Kinesis(...)` fails with "Kinesis is not a constructor". Adding `.default` is the fix.
+
+## AWS SDK for JavaScript v3
+
+v2 uses the AWS SDK v3 internally, in place of the v1 client's aws-sdk v2. The client builds the `@aws-sdk/client-*` packages it needs on its own, so you no longer depend on `aws-sdk` for this. A few option shapes follow the SDK's v3 conventions now.
+
+### Credentials
+
+v2 no longer reads top-level `accessKeyId`, `secretAccessKey`, or `sessionToken`. The v3 SDK takes a `credentials` object or a credential provider, so passing those keys now raises a clear error instead of being silently ignored.
+
+If you relied on the default provider chain (environment variables, shared config files, web identity tokens, the ECS/EC2 role), nothing changes. If you set keys directly, wrap them in a `credentials` object:
+
+```js
+// v1
+const kinesis = new Kinesis({
+  streamName: 'sample-stream',
+  accessKeyId: '<your-access-key-id>',
+  secretAccessKey: '<your-secret-access-key>'
+});
+
+// v2
+const kinesis = new Kinesis({
+  streamName: 'sample-stream',
+  credentials: {
+    accessKeyId: '<your-access-key-id>',
+    secretAccessKey: '<your-secret-access-key>'
+  }
+});
+```
+
+You can also pass a provider from `@aws-sdk/credential-providers`:
+
+```js
+import { fromIni } from '@aws-sdk/credential-providers';
+
+const kinesis = new Kinesis({
+  streamName: 'sample-stream',
+  credentials: fromIni({ profile: 'my-profile' })
+});
+```
+
+A `region` also needs to be resolvable, from `AWS_REGION`, your shared config, or the `region` option.
+
+### Other AWS options
+
+AWS client options pass through to the v3 clients, so option names follow v3. The one to watch for is S3 path-style addressing under the `s3` options: it's `forcePathStyle` now, where the v2 SDK called it `s3ForcePathStyle`.
+
+## Shard read errors recover instead of stopping the stream
+
+In v1, a fatal error while polling a shard was emitted on the client's `error` event, which usually stopped consumption of that shard until the process restarted. In v2 the client logs a warning, releases the shard's lease, and lets the shard be acquired again so it resumes from the last stored checkpoint.
+
+If you were listening on `error` to detect and recover from these yourself, you can lean on the built-in recovery instead. Producer errors, such as a rejected `putRecord`, still surface the same way as before.
+
+## What stayed the same
+
+The client options, methods, events, and the readable-stream interface match v1. Once you're on Node 22.12+ and importing the client the new way, existing consumer and producer code should keep working.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 Lifion's Node.js client for [Amazon Kinesis Data Streams](https://aws.amazon.com/kinesis/data-streams/).
 
+> **Upgrading from v1?** v2 requires Node.js 22.12+ and ships as an ES module. See the [migration guide](./MIGRATION.md) for the full list of changes.
+
 ## Getting Started
 
 To install the module:
@@ -12,16 +14,16 @@ To install the module:
 npm install lifion-kinesis --save
 ```
 
-The main module export is a Kinesis class that instantiates as a [readable stream](https://nodejs.org/dist/latest-v10.x/docs/api/stream.html#stream_readable_streams).
+The main module export is a Kinesis class that instantiates as a [readable stream](https://nodejs.org/api/stream.html#readable-streams).
 
 ```js
-const Kinesis = require('lifion-kinesis');
+import Kinesis from 'lifion-kinesis';
 
 const kinesis = new Kinesis({
   streamName: 'sample-stream'
-  /* other options from AWS.Kinesis */
+  /* plus any AWS SDK v3 client options */
 });
-kinesis.on('data', data => {
+kinesis.on('data', (data) => {
   console.log('Incoming data:', data);
 });
 kinesis.startConsumer();
@@ -30,19 +32,19 @@ kinesis.startConsumer();
 To take advantage of back-pressure, the client can be piped to a writable stream:
 
 ```js
-const { promisify } = require('util');
-const Kinesis = require('lifion-kinesis');
-const stream = require('stream');
+import { Writable, pipeline } from 'node:stream';
+import { promisify } from 'node:util';
+import Kinesis from 'lifion-kinesis';
 
-const asyncPipeline = promisify(stream.pipeline);
+const asyncPipeline = promisify(pipeline);
 const kinesis = new Kinesis({
   streamName: 'sample-stream'
-  /* other options from AWS.Kinesis */
+  /* plus any AWS SDK v3 client options */
 });
 
 asyncPipeline(
   kinesis,
-  new stream.Writable({
+  new Writable({
     objectMode: true,
     write(data, encoding, callback) {
       console.log(data);
@@ -60,7 +62,7 @@ Starting with v2, lifion-kinesis runs on the AWS SDK for JavaScript v3. In most 
 To run with specific credentials, pass a `credentials` object or an AWS [credential provider](https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/setting-credentials-node.html):
 
 ```js
-const { fromIni } = require('@aws-sdk/credential-providers');
+import { fromIni } from '@aws-sdk/credential-providers';
 
 const kinesis = new Kinesis({
   streamName: 'sample-stream',
@@ -70,9 +72,7 @@ const kinesis = new Kinesis({
 
 Any AWS SDK v3 client option (`region`, `endpoint`, `credentials`, and so on) can be set at the top level for the Kinesis client, and under the `dynamoDb` and `s3` options for those services.
 
-### Upgrading from v1
-
-The top-level `accessKeyId`, `secretAccessKey`, and `sessionToken` options are no longer read. The AWS SDK v3 only accepts a `credentials` object or provider, so passing those keys now raises a clear error. If you were setting them directly, wrap them in a `credentials` object. A `region` also needs to be resolvable, whether from `AWS_REGION`, your shared config, or the `region` option.
+> Upgrading from v1? The top-level `accessKeyId`, `secretAccessKey`, and `sessionToken` options are no longer read; wrap them in a `credentials` object instead. See the [migration guide](./MIGRATION.md) for this and the other changes in v2.
 
 ## Consuming records
 

--- a/templates/README.hbs
+++ b/templates/README.hbs
@@ -4,6 +4,8 @@
 
 Lifion's Node.js client for [Amazon Kinesis Data Streams](https://aws.amazon.com/kinesis/data-streams/).
 
+> **Upgrading from v1?** v2 requires Node.js 22.12+ and ships as an ES module. See the [migration guide](./MIGRATION.md) for the full list of changes.
+
 ## Getting Started
 
 To install the module:
@@ -12,16 +14,16 @@ To install the module:
 npm install lifion-kinesis --save
 ```
 
-The main module export is a Kinesis class that instantiates as a [readable stream](https://nodejs.org/dist/latest-v10.x/docs/api/stream.html#stream_readable_streams).
+The main module export is a Kinesis class that instantiates as a [readable stream](https://nodejs.org/api/stream.html#readable-streams).
 
 ```js
-const Kinesis = require('lifion-kinesis');
+import Kinesis from 'lifion-kinesis';
 
 const kinesis = new Kinesis({
   streamName: 'sample-stream'
-  /* other options from AWS.Kinesis */
+  /* plus any AWS SDK v3 client options */
 });
-kinesis.on('data', data => {
+kinesis.on('data', (data) => {
   console.log('Incoming data:', data);
 });
 kinesis.startConsumer();
@@ -30,19 +32,19 @@ kinesis.startConsumer();
 To take advantage of back-pressure, the client can be piped to a writable stream:
 
 ```js
-const { promisify } = require('util');
-const Kinesis = require('lifion-kinesis');
-const stream = require('stream');
+import { Writable, pipeline } from 'node:stream';
+import { promisify } from 'node:util';
+import Kinesis from 'lifion-kinesis';
 
-const asyncPipeline = promisify(stream.pipeline);
+const asyncPipeline = promisify(pipeline);
 const kinesis = new Kinesis({
   streamName: 'sample-stream'
-  /* other options from AWS.Kinesis */
+  /* plus any AWS SDK v3 client options */
 });
 
 asyncPipeline(
   kinesis,
-  new stream.Writable({
+  new Writable({
     objectMode: true,
     write(data, encoding, callback) {
       console.log(data);
@@ -60,7 +62,7 @@ Starting with v2, lifion-kinesis runs on the AWS SDK for JavaScript v3. In most 
 To run with specific credentials, pass a `credentials` object or an AWS [credential provider](https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/setting-credentials-node.html):
 
 ```js
-const { fromIni } = require('@aws-sdk/credential-providers');
+import { fromIni } from '@aws-sdk/credential-providers';
 
 const kinesis = new Kinesis({
   streamName: 'sample-stream',
@@ -70,9 +72,7 @@ const kinesis = new Kinesis({
 
 Any AWS SDK v3 client option (`region`, `endpoint`, `credentials`, and so on) can be set at the top level for the Kinesis client, and under the `dynamoDb` and `s3` options for those services.
 
-### Upgrading from v1
-
-The top-level `accessKeyId`, `secretAccessKey`, and `sessionToken` options are no longer read. The AWS SDK v3 only accepts a `credentials` object or provider, so passing those keys now raises a clear error. If you were setting them directly, wrap them in a `credentials` object. A `region` also needs to be resolvable, whether from `AWS_REGION`, your shared config, or the `region` option.
+> Upgrading from v1? The top-level `accessKeyId`, `secretAccessKey`, and `sessionToken` options are no longer read; wrap them in a `credentials` object instead. See the [migration guide](./MIGRATION.md) for this and the other changes in v2.
 
 ## Consuming records
 


### PR DESCRIPTION
Adds a v1 → v2 migration guide as part of the v2.0.0 release prep.

## Contents

- New `MIGRATION.md` (repo root) covering the breaking changes:
  - Node.js 22.12+ floor
  - ESM-only package (`import`, or `require(...).default` from CommonJS)
  - AWS SDK v3 (credentials object/provider, `region` must resolve, `s3ForcePathStyle` → `forcePathStyle`)
  - Shard read errors now self-heal instead of emitting `error` (#332)
- README: upgrade callout near the top linking to the guide; the inline "Upgrading from v1" details moved into the guide; usage examples updated from CommonJS `require` to ESM `import` (the old `const Kinesis = require('lifion-kinesis')` breaks under ESM).

`MIGRATION.md` is intentionally not shipped in the npm tarball (same `*.md` exclusion as `CHANGELOG.md`); the README's relative link resolves on GitHub and npm.