### PR TITLE
feat: support manual checkpoints for enhanced fan-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,10 +94,10 @@ In polling mode, `limit` (default `10000`) maps to the `Limit` parameter of the 
 
 ### Manual checkpoints and paused polling
 
-`setCheckpoint` and `continuePolling` show up as properties on that same `data` payload, so they're easy to miss if you go looking for them on the client itself. They're available in polling mode only (`useEnhancedFanOut: false`):
+`setCheckpoint` and `continuePolling` show up as properties on that same `data` payload, so they're easy to miss if you go looking for them on the client itself:
 
-- With `useAutoCheckpoints: false`, each `data` event includes `setCheckpoint(sequenceNumber)`. Call it once you've processed up to a record to store that sequence number as the shard's checkpoint.
-- With `usePausedPolling: true`, each `data` event includes `continuePolling()`. The client holds off on the next batch until you call it, which gives you room to finish processing first.
+- With `useAutoCheckpoints: false`, each `data` event includes `setCheckpoint(sequenceNumber)`. Call it once you've processed up to a record to store that sequence number as the shard's checkpoint. This works in both polling and enhanced fan-out mode (`useEnhancedFanOut: true`).
+- With `usePausedPolling: true`, each `data` event includes `continuePolling()`. The client holds off on the next batch until you call it, which gives you room to finish processing first. Paused polling applies to polling mode only (`useEnhancedFanOut: false`).
 
 ```js
 const kinesis = new Kinesis({

--- a/lib/consumers-manager.js
+++ b/lib/consumers-manager.js
@@ -200,6 +200,7 @@ class ConsumersManager {
                   stateStore,
                   stopConsumer,
                   streamName,
+                  useAutoCheckpoints,
                   useS3ForLargeItems,
                   ...shard
                 });

--- a/lib/fan-out-consumer.js
+++ b/lib/fan-out-consumer.js
@@ -170,8 +170,18 @@ class PostProcess extends Writable {
    * @param {function(Error, Object): void} options.pushToStream - A function that pushes records out of the pipeline.
    * @param {function(string): Promise<void>} options.setCheckpoint - A function that stores the checkpoint for the shard.
    * @param {string} options.shardId - The ID of the shard.
+   * @param {boolean} options.useAutoCheckpoints - Whether to automatically store the shard checkpoint
+   *        as records arrive, or to expose `setCheckpoint` on the pushed payload for manual use.
    */
-  constructor({ abort, logger, markShardAsDepleted, pushToStream, setCheckpoint, shardId }) {
+  constructor({
+    abort,
+    logger,
+    markShardAsDepleted,
+    pushToStream,
+    setCheckpoint,
+    shardId,
+    useAutoCheckpoints
+  }) {
     super({ objectMode: true });
     Object.assign(this.#data, {
       abort,
@@ -180,7 +190,8 @@ class PostProcess extends Writable {
       pushToStream,
       setCheckpoint,
       shardId,
-      timeoutId: null
+      timeoutId: null,
+      useAutoCheckpoints
     });
   }
 
@@ -197,18 +208,32 @@ class PostProcess extends Writable {
    * @param {function(Error=): void} callback - The callback for more data.
    */
   async _write(chunk, encoding, callback) {
-    const { abort, logger, markShardAsDepleted, pushToStream, setCheckpoint, shardId, timeoutId } =
-      this.#data;
+    const {
+      abort,
+      logger,
+      markShardAsDepleted,
+      pushToStream,
+      setCheckpoint,
+      shardId,
+      timeoutId,
+      useAutoCheckpoints
+    } = this.#data;
     clearTimeout(timeoutId);
     this.#data.timeoutId = setTimeout(abort, 10000);
     const { continuationSequenceNumber, millisBehindLatest, records } = chunk;
     if (continuationSequenceNumber !== undefined) {
-      await setCheckpoint(continuationSequenceNumber);
+      if (useAutoCheckpoints) {
+        await setCheckpoint(continuationSequenceNumber);
+      }
       const recordsCount = records.length;
       const msBehind = millisBehindLatest;
       if (recordsCount > 0) {
         logger.debug(`Got ${recordsCount} record(s) from "${shardId}" (${msBehind}ms behind)`);
-        pushToStream(null, { ...chunk, shardId });
+        pushToStream(null, {
+          ...chunk,
+          shardId,
+          ...(!useAutoCheckpoints && { setCheckpoint })
+        });
       }
       callback();
     } else {
@@ -244,6 +269,8 @@ class FanOutConsumer {
    * @param {function(): void} options.stopConsumer - A function that stops this consumer from the manager.
    * @param {string} options.streamName - The name of the Kinesis stream.
    *        user-intervention before polling for more records, or not.
+   * @param {boolean} options.useAutoCheckpoints - Whether to automatically store shard checkpoints
+   *        using the sequence number of the most-recently received record or not.
    * @param {boolean} options.useS3ForLargeItems - Whether to automatically use an S3
    *        bucket to store large items or not.
    */
@@ -265,6 +292,7 @@ class FanOutConsumer {
       stateStore,
       stopConsumer,
       streamName,
+      useAutoCheckpoints,
       useS3ForLargeItems
     } = options;
 
@@ -321,6 +349,7 @@ class FanOutConsumer {
       stopConsumer,
       stream: null,
       streamName,
+      useAutoCheckpoints,
       useS3ForLargeItems
     });
   }
@@ -350,6 +379,7 @@ class FanOutConsumer {
       stateStore,
       stopConsumer,
       streamName,
+      useAutoCheckpoints,
       useS3ForLargeItems
     } = privateProps;
 
@@ -441,7 +471,8 @@ class FanOutConsumer {
         markShardAsDepleted,
         pushToStream,
         setCheckpoint,
-        shardId
+        shardId,
+        useAutoCheckpoints
       });
 
       try {

--- a/lib/fan-out-consumer.test.js
+++ b/lib/fan-out-consumer.test.js
@@ -101,7 +101,8 @@ describe('lib/fan-out-consumer', () => {
     shardId: 'shard-0001',
     stateStore,
     stopConsumer,
-    streamName: 'test-stream'
+    streamName: 'test-stream',
+    useAutoCheckpoints: true
   };
 
   beforeEach(() => {
@@ -254,6 +255,40 @@ describe('lib/fan-out-consumer', () => {
 
     expect(stats.reportResponse).toHaveBeenCalledWith('kinesis', 'test-stream');
     expect(stats.reportError).not.toHaveBeenCalled();
+  });
+
+  test('with useAutoCheckpoints disabled, setCheckpoint is exposed for manual use', async () => {
+    const consumer = new FanOutConsumer({ ...options, useAutoCheckpoints: false });
+    const start = consumer.start();
+    await nextTickWait();
+    const { response } = got.getMocks();
+    response.emit('response', {
+      headers: { 'content-type': 'application/vnd.amazon.eventstream' },
+      statusCode: 200
+    });
+    response.push({
+      continuationSequenceNumber: '2',
+      millisBehindLatest: 0,
+      records: [{ foo: 'bar' }]
+    });
+
+    await nextTickWait();
+    response.emit('error', Object.assign(new Error('foo'), { code: 'ValidationException' }));
+    await start;
+
+    expect(storeShardCheckpoint).not.toHaveBeenCalled();
+
+    expect(pushToStream).toHaveBeenNthCalledWith(1, null, {
+      continuationSequenceNumber: '2',
+      millisBehindLatest: 0,
+      records: [{ foo: 'bar' }],
+      setCheckpoint: expect.any(Function),
+      shardId: 'shard-0001'
+    });
+
+    const { setCheckpoint } = pushToStream.mock.calls[0][1];
+    await setCheckpoint('1');
+    expect(storeShardCheckpoint).toHaveBeenCalledWith('shard-0001', '1', '#a', { '#a': 'a' });
   });
 
   test('passing a TRIM_HORIZON initialPositionInStream starts a TRIM_HORIZON stream', async () => {

--- a/templates/README.hbs
+++ b/templates/README.hbs
@@ -94,10 +94,10 @@ In polling mode, `limit` (default `10000`) maps to the `Limit` parameter of the 
 
 ### Manual checkpoints and paused polling
 
-`setCheckpoint` and `continuePolling` show up as properties on that same `data` payload, so they're easy to miss if you go looking for them on the client itself. They're available in polling mode only (`useEnhancedFanOut: false`):
+`setCheckpoint` and `continuePolling` show up as properties on that same `data` payload, so they're easy to miss if you go looking for them on the client itself:
 
-- With `useAutoCheckpoints: false`, each `data` event includes `setCheckpoint(sequenceNumber)`. Call it once you've processed up to a record to store that sequence number as the shard's checkpoint.
-- With `usePausedPolling: true`, each `data` event includes `continuePolling()`. The client holds off on the next batch until you call it, which gives you room to finish processing first.
+- With `useAutoCheckpoints: false`, each `data` event includes `setCheckpoint(sequenceNumber)`. Call it once you've processed up to a record to store that sequence number as the shard's checkpoint. This works in both polling and enhanced fan-out mode (`useEnhancedFanOut: true`).
+- With `usePausedPolling: true`, each `data` event includes `continuePolling()`. The client holds off on the next batch until you call it, which gives you room to finish processing first. Paused polling applies to polling mode only (`useEnhancedFanOut: false`).
 
 ```js
 const kinesis = new Kinesis({


### PR DESCRIPTION
## Summary

`useAutoCheckpoints` was only threaded to polling consumers. The enhanced fan-out consumer stored a checkpoint on every chunk regardless of the option, so manual checkpointing was effectively unavailable in fan-out mode (the gap reported in #387).

This wires `useAutoCheckpoints` through `consumers-manager` → `fan-out-consumer` → its `PostProcess` writable, mirroring the polling consumer:

- **`useAutoCheckpoints: true` (default)** — unchanged: stores the continuation sequence number on each chunk before delivering records.
- **`useAutoCheckpoints: false`** — no automatic checkpoint; each `data` event payload carries a `setCheckpoint(sequenceNumber)` function so consumers persist a checkpoint only after they've finished processing.

Paused polling (`continuePolling`) stays polling-only; only the manual-checkpoint half of that contract applies to fan-out.

## Docs

README "Manual checkpoints and paused polling" section updated to note `setCheckpoint` works in both polling and enhanced fan-out, while paused polling remains polling-only (regenerated via `build-docs`).

## Testing

- Unit: 444/444, 100% coverage (added a manual-mode fan-out test asserting no auto-checkpoint + `setCheckpoint` exposed on the payload + that calling it stores the sequence number).
- LocalStack integration: fan-out + polling suites pass (validates the default auto-checkpoint path end-to-end).
- Smoke + eslint clean.

Closes #387