### PR TITLE
feat: expose shard assignments per consumer

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,23 @@ kinesis.on('data', async ({ records, setCheckpoint, continuePolling }) => {
 kinesis.startConsumer();
 ```
 
+### Inspecting shard assignments
+
+When several consumers share a group, the client spreads the stream's shards across them. `getShardAssignments()` reports who currently owns what, keyed by consumer ID, so you can see how the work is distributed without querying the DynamoDB state table yourself. The consumer has to be started first.
+
+```js
+const kinesis = new Kinesis({ streamName: 'sample-stream' });
+await kinesis.startConsumer();
+
+const assignments = await kinesis.getShardAssignments();
+// {
+//   'consumer-a': { host, pid, isActive, shards: ['shardId-000000000000', …], … },
+//   'consumer-b': { … }
+// }
+```
+
+Each entry carries the consumer's `appName`, `host`, `pid`, `startedOn`, `heartbeat`, `isActive`, and `isStandalone`, along with the sorted `shards` it's assigned.
+
 ## Features
 
 - Standard [Node.js stream abstraction](https://nodejs.org/dist/latest-v10.x/docs/api/stream.html#stream_stream) of Kinesis streams.
@@ -227,6 +244,7 @@ The credentials the client runs with need DynamoDB access to the table: `CreateT
             * [.listShards(params)](#module_lifion-kinesis--Kinesis+listShards) ⇒ <code>Promise</code>
             * [.putRecords(params)](#module_lifion-kinesis--Kinesis+putRecords) ⇒ <code>Promise</code>
             * [.getStats()](#module_lifion-kinesis--Kinesis+getStats) ⇒ <code>Object</code>
+            * [.getShardAssignments()](#module_lifion-kinesis--Kinesis+getShardAssignments) ⇒ <code>Promise</code>
         * _static_
             * [.getStats()](#module_lifion-kinesis--Kinesis.getStats) ⇒ <code>Object</code>
 
@@ -357,6 +375,17 @@ Returns statistics for the instance of the client.
 
 **Kind**: instance method of [<code>Kinesis</code>](#exp_module_lifion-kinesis--Kinesis)  
 **Returns**: <code>Object</code> - An object with the statistics.  
+<a name="module_lifion-kinesis--Kinesis+getShardAssignments"></a>
+
+#### kinesis.getShardAssignments() ⇒ <code>Promise</code>
+Returns the shards assigned to each consumer in the same group, so it's possible to inspect
+how the stream shards are currently distributed across the consumers sharing a group. The
+consumer must be started before calling this (see `startConsumer`).
+
+**Kind**: instance method of [<code>Kinesis</code>](#exp_module_lifion-kinesis--Kinesis)  
+**Fulfil**: <code>Object</code> - A map keyed by consumer ID, where each entry has the consumer details and
+       a sorted array with the IDs of the shards assigned to that consumer.  
+**Reject**: <code>Error</code> - If the consumer hasn't been started yet.  
 <a name="module_lifion-kinesis--Kinesis.getStats"></a>
 
 #### Kinesis.getStats() ⇒ <code>Object</code>

--- a/lib/index.js
+++ b/lib/index.js
@@ -637,6 +637,24 @@ class Kinesis extends PassThrough {
   }
 
   /**
+   * Returns the shards assigned to each consumer in the same group, so it's possible to inspect
+   * how the stream shards are currently distributed across the consumers sharing a group. The
+   * consumer must be started before calling this (see `startConsumer`).
+   *
+   * @fulfil {Object} - A map keyed by consumer ID, where each entry has the consumer details and
+   *        a sorted array with the IDs of the shards assigned to that consumer.
+   * @reject {Error} - If the consumer hasn't been started yet.
+   * @returns {Promise}
+   */
+  async getShardAssignments() {
+    const { stateStore } = this.#data;
+    if (!stateStore) {
+      throw new Error('Call startConsumer before getting the shard assignments.');
+    }
+    return stateStore.getShardAssignments();
+  }
+
+  /**
    * Returns the aggregated statistics of all the instances of the client.
    *
    * @returns {Object} An object with the statistics.

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -107,6 +107,9 @@ vi.mock('./state-store', () => {
   };
   const start = vi.fn();
   const getEnhancedConsumers = vi.fn(() => Promise.resolve(enhancedConsumers));
+  const getShardAssignments = vi.fn(() =>
+    Promise.resolve({ 'consumer-id': { shards: ['shard'] } })
+  );
   const registerEnhancedConsumer = vi.fn((consumerName, arn) => {
     enhancedConsumers[consumerName] = { arn };
     return Promise.resolve();
@@ -122,6 +125,7 @@ vi.mock('./state-store', () => {
         clearMockData,
         deregisterEnhancedConsumer,
         getEnhancedConsumers,
+        getShardAssignments,
         registerEnhancedConsumer,
         start,
         stop
@@ -600,6 +604,27 @@ describe('lib/index', () => {
 
   test('stats can be retrieved for the module', () => {
     expect(Kinesis.getStats()).toEqual({ stats: {} });
+  });
+
+  test('shard assignments can be retrieved once the consumer is started', async () => {
+    const kinesis = new Kinesis(options);
+    try {
+      await kinesis.startConsumer();
+      await expect(kinesis.getShardAssignments()).resolves.toEqual({
+        'consumer-id': { shards: ['shard'] }
+      });
+      const stateStore = new StateStore();
+      expect(stateStore.getShardAssignments).toHaveBeenCalled();
+    } finally {
+      kinesis.stopConsumer();
+    }
+  });
+
+  test('getting shard assignments before starting the consumer rejects', async () => {
+    const kinesis = new Kinesis(options);
+    await expect(kinesis.getShardAssignments()).rejects.toThrow(
+      'Call startConsumer before getting the shard assignments.'
+    );
   });
 
   describe('listShards', () => {

--- a/lib/state-store.js
+++ b/lib/state-store.js
@@ -486,6 +486,56 @@ class StateStore {
   }
 
   /**
+   * Returns the shards assigned to each consumer registered in the same group, keyed by consumer
+   * ID. Useful to inspect how the stream shards are currently distributed across the consumers
+   * that share a consumer group. The shard ownership is resolved from wherever the state stores
+   * it for the active mode: the shard lease owners when using automatic shard assignment, or each
+   * consumer's own shards when reading from all shards (including enhanced fan-out).
+   *
+   * @fulfil {Object} - A map of consumer ID to an object with the consumer details and a sorted
+   *        array of the IDs of the shards assigned to it.
+   * @returns {Promise}
+   */
+  async getShardAssignments() {
+    const { consumers, enhancedConsumers, shards } = await getStreamState(this.#data);
+
+    const ownedShardIds = Object.entries(consumers).reduce(
+      (obj, [consumerId, { shards: consumerShards }]) => ({
+        ...obj,
+        [consumerId]: new Set(Object.keys(consumerShards || {}))
+      }),
+      {}
+    );
+
+    Object.entries(shards).forEach(([shardId, { leaseOwner }]) => {
+      if (leaseOwner && ownedShardIds[leaseOwner]) ownedShardIds[leaseOwner].add(shardId);
+    });
+
+    Object.values(enhancedConsumers).forEach(({ isUsedBy, shards: consumerShards }) => {
+      if (isUsedBy && ownedShardIds[isUsedBy] && consumerShards) {
+        Object.keys(consumerShards).forEach((shardId) => ownedShardIds[isUsedBy].add(shardId));
+      }
+    });
+
+    return Object.entries(consumers).reduce((obj, [consumerId, consumer]) => {
+      const { appName, heartbeat, host, isActive, isStandalone, pid, startedOn } = consumer;
+      return {
+        ...obj,
+        [consumerId]: {
+          appName,
+          heartbeat,
+          host,
+          isActive,
+          isStandalone,
+          pid,
+          shards: Array.from(ownedShardIds[consumerId]).sort(),
+          startedOn
+        }
+      };
+    }, {});
+  }
+
+  /**
    * Returns the current state of the stream shards and pointers that can be used to update the
    * stream shard state in subsequent calls. This is useful as the shards state is stored in
    * different locations depending on the consumer usage scenario.

--- a/lib/state-store.test.js
+++ b/lib/state-store.test.js
@@ -70,6 +70,7 @@ describe('lib/state-store', () => {
       'getEnhancedConsumers',
       'getOwnedShards',
       'getShardAndStreamState',
+      'getShardAssignments',
       'getShardsData',
       'lockShardLease',
       'markShardAsDepleted',
@@ -800,6 +801,79 @@ describe('lib/state-store', () => {
         checkpoint: '1',
         leaseExpiration: fiveMinsFromNow,
         version: '0000'
+      }
+    });
+  });
+
+  test('getShardAssignments groups owned shards by consumer when auto-assigning', async () => {
+    const state = new StateStore(options);
+    await state.start();
+    const { get } = new DynamoDbClient();
+    const consumer = (host, pid) => ({
+      appName: 'app',
+      heartbeat: '2019-01-01T00:00:00.000Z',
+      host,
+      isActive: true,
+      isStandalone: false,
+      pid,
+      startedOn: '2019-01-01T00:00:00.000Z'
+    });
+    get.mockResolvedValueOnce({
+      Item: {
+        consumers: { 'consumer-a': consumer('host-a', 100), 'consumer-b': consumer('host-b', 200) },
+        enhancedConsumers: {},
+        shards: {
+          'shard-0000': { leaseOwner: 'consumer-a' },
+          'shard-0001': { leaseOwner: 'consumer-b' },
+          'shard-0002': { leaseOwner: 'consumer-a' },
+          'shard-0003': { leaseOwner: null },
+          'shard-0004': { leaseOwner: 'gone-consumer' }
+        }
+      }
+    });
+    await expect(state.getShardAssignments()).resolves.toEqual({
+      'consumer-a': { ...consumer('host-a', 100), shards: ['shard-0000', 'shard-0002'] },
+      'consumer-b': { ...consumer('host-b', 200), shards: ['shard-0001'] }
+    });
+  });
+
+  test('getShardAssignments resolves per-consumer shards when not auto-assigning', async () => {
+    const state = new StateStore(options);
+    await state.start();
+    const { get } = new DynamoDbClient();
+    const consumer = (extra) => ({
+      appName: 'app',
+      heartbeat: '2019-01-01T00:00:00.000Z',
+      host: 'host',
+      isActive: true,
+      isStandalone: true,
+      pid: 1,
+      startedOn: '2019-01-01T00:00:00.000Z',
+      ...extra
+    });
+    get.mockResolvedValueOnce({
+      Item: {
+        consumers: {
+          'fanout-consumer': consumer(),
+          'polling-consumer': consumer({ shards: { 'shard-0000': {}, 'shard-0001': {} } })
+        },
+        enhancedConsumers: {
+          free: { isUsedBy: null, shards: {} },
+          'in-use': { isUsedBy: 'fanout-consumer', shards: { 'shard-0002': {} } },
+          'in-use-no-shards': { isUsedBy: 'fanout-consumer' },
+          orphaned: { isUsedBy: 'gone-consumer', shards: { 'shard-0009': {} } }
+        },
+        shards: {}
+      }
+    });
+    await expect(state.getShardAssignments()).resolves.toEqual({
+      'fanout-consumer': {
+        ...consumer(),
+        shards: ['shard-0002']
+      },
+      'polling-consumer': {
+        ...consumer(),
+        shards: ['shard-0000', 'shard-0001']
       }
     });
   });

--- a/templates/README.hbs
+++ b/templates/README.hbs
@@ -117,6 +117,23 @@ kinesis.on('data', async ({ records, setCheckpoint, continuePolling }) => {
 kinesis.startConsumer();
 ```
 
+### Inspecting shard assignments
+
+When several consumers share a group, the client spreads the stream's shards across them. `getShardAssignments()` reports who currently owns what, keyed by consumer ID, so you can see how the work is distributed without querying the DynamoDB state table yourself. The consumer has to be started first.
+
+```js
+const kinesis = new Kinesis({ streamName: 'sample-stream' });
+await kinesis.startConsumer();
+
+const assignments = await kinesis.getShardAssignments();
+// {
+//   'consumer-a': { host, pid, isActive, shards: ['shardId-000000000000', …], … },
+//   'consumer-b': { … }
+// }
+```
+
+Each entry carries the consumer's `appName`, `host`, `pid`, `startedOn`, `heartbeat`, `isActive`, and `isStandalone`, along with the sorted `shards` it's assigned.
+
 ## Features
 
 - Standard [Node.js stream abstraction](https://nodejs.org/dist/latest-v10.x/docs/api/stream.html#stream_stream) of Kinesis streams.


### PR DESCRIPTION
## Summary

Adds `Kinesis#getShardAssignments()`, a read-only view of how a stream's shards are distributed across the consumers in a group, keyed by consumer ID. Until now this was only reachable by querying the DynamoDB state table directly (the gap in #316).

The state store resolves ownership from wherever it records it for the active mode:
- **Automatic shard assignment** (default) — from each shard's `leaseOwner`.
- **Reading from all shards** (`useAutoShardAssignment: false`) — from each consumer's own `shards` map.
- **Standalone enhanced fan-out** — from `enhancedConsumers[].shards`, mapped back to the owning consumer via `isUsedBy`.

Each entry returns the consumer details (`appName`, `host`, `pid`, `startedOn`, `heartbeat`, `isActive`, `isStandalone`) and a sorted array of its assigned shard IDs. The consumer must be started first (the state store is created in `startConsumer`); calling it earlier rejects with a clear error.

## Docs

README gets an "Inspecting shard assignments" section plus the auto-generated API entry (regenerated via `build-docs`).

## Testing

- Unit: 447/447, 100% coverage. New state-store tests cover the auto-assignment grouping and the standalone polling + fan-out layouts (including null/stale lease owners and `isUsedBy`); new index tests cover the delegation and the not-started rejection.
- LocalStack: ran a live `getShardAssignments()` against a running consumer (1 consumer / 1 shard, full metadata as expected); integration + smoke suites still pass.
- eslint clean.

Closes #316