### PR TITLE
feat: deregister idle enhanced fan-out consumers

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,10 @@ References:
 - [`SubscribeToShard` API reference](https://docs.aws.amazon.com/kinesis/latest/APIReference/API_SubscribeToShard.html), which also describes it as establishing an HTTP/2 connection.
 - [aws-sdk-cpp #3115](https://github.com/aws/aws-sdk-cpp/discussions/3115) and [#3118](https://github.com/aws/aws-sdk-cpp/issues/3118), where others observe `SubscribeToShard` going over HTTP/1.1 with batchy, high-latency delivery.
 
+### Deregistering idle enhanced consumers
+
+The client pre-registers up to `maxEnhancedConsumers` enhanced fan-out consumers, and AWS bills for each registered consumer whether or not it's reading. If your consumer group scales down, the extra consumers sit idle and keep costing money. Set `enhancedConsumerIdleTimeout` (in milliseconds) to have the client deregister consumers that have stayed unused for that long, keeping at least one. They get re-registered as the group scales back up, which takes a little while since AWS has to make each one active again, so pick a timeout comfortably larger than your lease and heartbeat cycles. It defaults to `0`, which leaves every registered consumer in place.
+
 ## State table (DynamoDB)
 
 The client stores its consumer state (shard leases and checkpoints) in a DynamoDB table, and it creates and manages that table for you. You don't have to create it ahead of time.
@@ -275,7 +279,8 @@ Initializes a new instance of the Kinesis client.
 | [options.encryption] | <code>Object</code> |  | The encryption options to enforce in the stream. |
 | [options.encryption.type] | <code>string</code> |  | The encryption type to use. |
 | [options.encryption.keyId] | <code>string</code> |  | The GUID for the customer-managed AWS KMS key        to use for encryption. This value can be a globally unique identifier, a fully        specified ARN to either an alias or a key, or an alias name prefixed by "alias/". |
-| [options.initialPositionInStream] | <code>string</code> | <code>&quot;LATEST&quot;</code> | The location in the shard from which the Consumer will start         fetching records from when the application starts for the first time and there is no checkpoint for the shard.        Set to LATEST to fetch new data only        Set to TRIM_HORIZON to start from the oldest available data record. |
+| [options.enhancedConsumerIdleTimeout] | <code>number</code> | <code>0</code> | When greater than `0` and        `useEnhancedFanOut` is `true`, enhanced fan-out consumers that have stayed unused for        at least this many milliseconds are deregistered from AWS (so they stop incurring        charges), keeping at least one registered. They are re-registered as the consumer group        scales back up, which takes time as AWS makes them active. Set this comfortably above        the lease and heartbeat cycles to avoid removing consumers that are briefly idle.        Defaults to `0`, which keeps every registered consumer in place. |
+| [options.initialPositionInStream] | <code>string</code> | <code>&quot;LATEST&quot;</code> | The location in the shard from which the Consumer will start        fetching records from when the application starts for the first time and there is no checkpoint for the shard.        Set to LATEST to fetch new data only        Set to TRIM_HORIZON to start from the oldest available data record. |
 | [options.leaseAcquisitionInterval] | <code>number</code> | <code>20000</code> | The interval in milliseconds for how often to        attempt lease acquisitions. |
 | [options.leaseAcquisitionRecoveryInterval] | <code>number</code> | <code>5000</code> | The interval in milliseconds for how often        to re-attempt lease acquisitions when an error is returned from aws. |
 | [options.limit] | <code>number</code> | <code>10000</code> | The maximum number of records to request in a single        `GetRecords` call (only applicable when `useEnhancedFanOut` is set to `false`). Kinesis        may return fewer records than this; the client keeps polling to deliver the rest. |

--- a/lib/heartbeat-manager.js
+++ b/lib/heartbeat-manager.js
@@ -24,11 +24,22 @@ class HeartbeatManager {
    * Initializes an instance of the hearbeat manager.
    *
    * @param {Object} options - The initialization options.
+   * @param {Object} options.client - An instance of the Kinesis client, used to deregister idle
+   *        enhanced fan-out consumers from AWS.
+   * @param {number} options.enhancedConsumerIdleTimeout - When greater than `0`, the idle timeout
+   *        in milliseconds after which unused enhanced fan-out consumers are deregistered.
    * @param {Object} options.logger - An instance of a logger.
    * @param {Object} options.stateStore - An instance of the state store.
+   * @param {boolean} options.useEnhancedFanOut - Whether the client is using enhanced fan-out.
    */
-  constructor({ logger, stateStore }) {
-    Object.assign(this.#data, { logger, stateStore });
+  constructor({ client, enhancedConsumerIdleTimeout, logger, stateStore, useEnhancedFanOut }) {
+    Object.assign(this.#data, {
+      client,
+      enhancedConsumerIdleTimeout,
+      logger,
+      stateStore,
+      useEnhancedFanOut
+    });
   }
 
   /**
@@ -40,7 +51,14 @@ class HeartbeatManager {
    */
   async start() {
     const privateProps = this.#data;
-    const { logger, stateStore, timeoutId } = privateProps;
+    const {
+      client,
+      enhancedConsumerIdleTimeout,
+      logger,
+      stateStore,
+      timeoutId,
+      useEnhancedFanOut
+    } = privateProps;
 
     if (timeoutId) return;
 
@@ -48,6 +66,9 @@ class HeartbeatManager {
       try {
         await stateStore.registerConsumer();
         await stateStore.clearOldConsumers(HEARTBEAT_FAILURE_TIMEOUT);
+        if (useEnhancedFanOut && enhancedConsumerIdleTimeout > 0) {
+          await stateStore.deregisterIdleEnhancedConsumers(client, enhancedConsumerIdleTimeout);
+        }
         logger.debug('Heartbeat sent.');
       } catch (err) {
         logger.error('Unexpected recoverable failure when trying to send a hearbeat:', err);

--- a/lib/heartbeat-manager.test.js
+++ b/lib/heartbeat-manager.test.js
@@ -11,8 +11,10 @@ describe('lib/heartbeat-manager', () => {
   const error = vi.fn();
   const logger = { debug, error };
   const clearOldConsumers = vi.fn();
+  const deregisterIdleEnhancedConsumers = vi.fn();
   const registerConsumer = vi.fn();
-  const stateStore = { clearOldConsumers, registerConsumer };
+  const stateStore = { clearOldConsumers, deregisterIdleEnhancedConsumers, registerConsumer };
+  const client = { deregisterStreamConsumer: vi.fn() };
 
   beforeEach(() => {
     vi.useFakeTimers({
@@ -24,6 +26,7 @@ describe('lib/heartbeat-manager', () => {
     debug.mockClear();
     error.mockClear();
     clearOldConsumers.mockClear();
+    deregisterIdleEnhancedConsumers.mockClear();
     registerConsumer.mockClear();
   });
 
@@ -43,6 +46,34 @@ describe('lib/heartbeat-manager', () => {
     expect(registerConsumer).toHaveBeenCalledTimes(2);
     expect(debug).toHaveBeenCalled();
     expect(debug).toHaveBeenCalledTimes(2);
+    manager.stop();
+  });
+
+  test('the heartbeat manager deregisters idle enhanced consumers when enabled', async () => {
+    const manager = new HeartbeatManager({
+      client,
+      enhancedConsumerIdleTimeout: 1000,
+      logger,
+      stateStore,
+      useEnhancedFanOut: true
+    });
+    await manager.start();
+    await nextTickWait();
+    expect(deregisterIdleEnhancedConsumers).toHaveBeenCalledWith(client, 1000);
+    manager.stop();
+  });
+
+  test('the heartbeat manager skips idle deregistration when not using enhanced fan-out', async () => {
+    const manager = new HeartbeatManager({
+      client,
+      enhancedConsumerIdleTimeout: 1000,
+      logger,
+      stateStore,
+      useEnhancedFanOut: false
+    });
+    await manager.start();
+    await nextTickWait();
+    expect(deregisterIdleEnhancedConsumers).not.toHaveBeenCalled();
     manager.stop();
   });
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -242,7 +242,14 @@ class Kinesis extends PassThrough {
    * @param {string} [options.encryption.keyId] - The GUID for the customer-managed AWS KMS key
    *        to use for encryption. This value can be a globally unique identifier, a fully
    *        specified ARN to either an alias or a key, or an alias name prefixed by "alias/".
-   * @param {string} [options.initialPositionInStream=LATEST] - The location in the shard from which the Consumer will start 
+   * @param {number} [options.enhancedConsumerIdleTimeout=0] - When greater than `0` and
+   *        `useEnhancedFanOut` is `true`, enhanced fan-out consumers that have stayed unused for
+   *        at least this many milliseconds are deregistered from AWS (so they stop incurring
+   *        charges), keeping at least one registered. They are re-registered as the consumer group
+   *        scales back up, which takes time as AWS makes them active. Set this comfortably above
+   *        the lease and heartbeat cycles to avoid removing consumers that are briefly idle.
+   *        Defaults to `0`, which keeps every registered consumer in place.
+   * @param {string} [options.initialPositionInStream=LATEST] - The location in the shard from which the Consumer will start
    *        fetching records from when the application starts for the first time and there is no checkpoint for the shard.
    *        Set to LATEST to fetch new data only
    *        Set to TRIM_HORIZON to start from the oldest available data record.
@@ -320,6 +327,7 @@ class Kinesis extends PassThrough {
       createStreamIfNeeded = true,
       dynamoDb = {},
       encryption,
+      enhancedConsumerIdleTimeout = 0,
       initialPositionInStream = 'LATEST',
       leaseAcquisitionInterval = 20000,
       leaseAcquisitionRecoveryInterval = 5000,
@@ -384,6 +392,10 @@ class Kinesis extends PassThrough {
       createStreamIfNeeded,
       dynamoDb,
       encryption,
+      enhancedConsumerIdleTimeout: boundedNumber(enhancedConsumerIdleTimeout, {
+        fallback: 0,
+        min: 0
+      }),
       getStatsIntervalId: null,
       initialPositionInStream:
         initialPositionInStream === 'TRIM_HORIZON' ? 'TRIM_HORIZON' : 'LATEST',

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -627,6 +627,18 @@ describe('lib/index', () => {
     );
   });
 
+  test('the enhancedConsumerIdleTimeout option is passed to the heartbeat manager', async () => {
+    const kinesis = new Kinesis({ ...options, enhancedConsumerIdleTimeout: 60000 });
+    try {
+      await kinesis.startConsumer();
+      expect(HeartbeatManager).toHaveBeenCalledWith(
+        expect.objectContaining({ enhancedConsumerIdleTimeout: 60000 })
+      );
+    } finally {
+      kinesis.stopConsumer();
+    }
+  });
+
   describe('listShards', () => {
     test('lists shards', async () => {
       const kinesis = new Kinesis(options);

--- a/lib/state-store.js
+++ b/lib/state-store.js
@@ -287,16 +287,18 @@ class StateStore {
               '#a': 'enhancedConsumers',
               '#b': consumerName,
               '#c': 'isUsedBy',
-              '#d': 'version'
+              '#d': 'version',
+              '#e': 'releasedOn'
             },
             ExpressionAttributeValues: {
+              ':v': new Date().toISOString(),
               ':w': isUsedBy,
               ':x': ver,
               ':y': null,
               ':z': generate()
             },
             Key: { consumerGroup, streamName },
-            UpdateExpression: 'SET #a.#b.#c = :y, #a.#b.#d = :z'
+            UpdateExpression: 'SET #a.#b.#c = :y, #a.#b.#d = :z, #a.#b.#e = :v'
           });
           logger.debug(`Enhanced consumer "${consumerName}" has been released.`);
         } catch (err) {
@@ -337,6 +339,74 @@ class StateStore {
         throw err;
       }
     }
+  }
+
+  /**
+   * Deregisters the enhanced fan-out consumers that have stayed unused for at least the given idle
+   * timeout, both from the stream state and from AWS, so they stop incurring charges. At least one
+   * enhanced consumer is always kept. Each removal from the state is guarded on the consumer still
+   * being unused, so a consumer that gets assigned to a client in the meantime is left in place,
+   * and the AWS de-registration only happens once the state removal wins that guard.
+   *
+   * @param {Object} kinesisClient - An instance of the Kinesis client, used to deregister the
+   *        enhanced consumers from AWS.
+   * @param {number} idleTimeout - The number of milliseconds a consumer must have stayed unused
+   *        before it can be deregistered.
+   * @fulfil {undefined}
+   * @returns {Promise}
+   */
+  async deregisterIdleEnhancedConsumers(kinesisClient, idleTimeout) {
+    const { client, consumerGroup, logger, streamName } = this.#data;
+    const { enhancedConsumers } = await getStreamState(this.#data);
+    const consumerNames = Object.keys(enhancedConsumers);
+
+    const idleNames = consumerNames.filter((name) => {
+      const { isUsedBy, releasedOn } = enhancedConsumers[name];
+      return (
+        isUsedBy == null &&
+        releasedOn != null &&
+        Date.now() - new Date(releasedOn).getTime() > idleTimeout
+      );
+    });
+
+    const keptCount = consumerNames.length - idleNames.length;
+    const removableNames = keptCount > 0 ? idleNames : idleNames.slice(1);
+
+    await Promise.all(
+      removableNames.map(async (name) => {
+        const { arn, version } = enhancedConsumers[name];
+        let removed = false;
+        try {
+          await client.update({
+            ConditionExpression: '#a.#b.#c = :v AND #a.#b.#d = :w',
+            ExpressionAttributeNames: {
+              '#a': 'enhancedConsumers',
+              '#b': name,
+              '#c': 'isUsedBy',
+              '#d': 'version'
+            },
+            ExpressionAttributeValues: { ':v': null, ':w': version },
+            Key: { consumerGroup, streamName },
+            UpdateExpression: 'REMOVE #a.#b'
+          });
+          removed = true;
+        } catch (err) {
+          if (err.code !== 'ConditionalCheckFailedException') {
+            logger.error(err);
+            throw err;
+          }
+          logger.debug(`Enhanced consumer "${name}" is in use again, will not deregister it.`);
+        }
+        if (removed) {
+          try {
+            await kinesisClient.deregisterStreamConsumer({ ConsumerARN: arn });
+            logger.debug(`Deregistered idle enhanced consumer "${name}".`);
+          } catch (err) {
+            logger.warn(`Could not deregister idle enhanced consumer "${name}" from AWS:`, err);
+          }
+        }
+      })
+    );
   }
 
   /**
@@ -807,6 +877,7 @@ class StateStore {
             arn,
             isStandalone: !useAutoShardAssignment,
             isUsedBy: null,
+            releasedOn: new Date().toISOString(),
             version: generate(),
             ...(!useAutoShardAssignment && { shards: {} })
           }

--- a/lib/state-store.test.js
+++ b/lib/state-store.test.js
@@ -65,6 +65,7 @@ describe('lib/state-store', () => {
       'constructor',
       'clearOldConsumers',
       'deregisterEnhancedConsumer',
+      'deregisterIdleEnhancedConsumers',
       'ensureShardStateExists',
       'getAssignedEnhancedConsumer',
       'getEnhancedConsumers',
@@ -223,9 +224,11 @@ describe('lib/state-store', () => {
         '#a': 'enhancedConsumers',
         '#b': 'enhanced-consumer-1',
         '#c': 'isUsedBy',
-        '#d': 'version'
+        '#d': 'version',
+        '#e': 'releasedOn'
       },
       ExpressionAttributeValues: {
+        ':v': expect.stringMatching(/^\d{4}-\d{2}-\d{2}T/),
         ':w': 'consumer-2',
         ':x': undefined,
         ':y': null,
@@ -235,7 +238,7 @@ describe('lib/state-store', () => {
         consumerGroup: 'test-group',
         streamName: 'test-stream'
       },
-      UpdateExpression: 'SET #a.#b.#c = :y, #a.#b.#d = :z'
+      UpdateExpression: 'SET #a.#b.#c = :y, #a.#b.#d = :z, #a.#b.#e = :v'
     });
 
     expect(update).toHaveBeenCalledTimes(2);
@@ -354,9 +357,11 @@ describe('lib/state-store', () => {
         '#a': 'enhancedConsumers',
         '#b': 'enhanced-consumer-1',
         '#c': 'isUsedBy',
-        '#d': 'version'
+        '#d': 'version',
+        '#e': 'releasedOn'
       },
       ExpressionAttributeValues: {
+        ':v': expect.stringMatching(/^\d{4}-\d{2}-\d{2}T/),
         ':w': 'consumer-1',
         ':x': undefined,
         ':y': null,
@@ -366,7 +371,7 @@ describe('lib/state-store', () => {
         consumerGroup: 'test-group',
         streamName: 'test-stream'
       },
-      UpdateExpression: 'SET #a.#b.#c = :y, #a.#b.#d = :z'
+      UpdateExpression: 'SET #a.#b.#c = :y, #a.#b.#d = :z, #a.#b.#e = :v'
     });
 
     expect(update).toHaveBeenCalledTimes(1);
@@ -443,6 +448,188 @@ describe('lib/state-store', () => {
     await expect(store.deregisterEnhancedConsumer('enhanced-consumer-1')).rejects.toThrow('foo');
     expect(error).toHaveBeenNthCalledWith(1, expect.objectContaining({ message: 'foo' }));
     expect(error).toHaveBeenCalledTimes(1);
+  });
+
+  test('deregisterIdleEnhancedConsumers deregisters consumers idle past the timeout', async () => {
+    const store = new StateStore(options);
+    await store.start();
+    const { get, update } = new DynamoDbClient();
+    const kinesisClient = { deregisterStreamConsumer: vi.fn(() => Promise.resolve()) };
+    get.mockResolvedValueOnce({
+      Item: {
+        enhancedConsumers: {
+          'idle-never-released': {
+            arn: 'arn:idle-never-released',
+            isUsedBy: null,
+            version: 'v-nr'
+          },
+          'idle-old': {
+            arn: 'arn:idle-old',
+            isUsedBy: null,
+            releasedOn: '2019-01-01T00:00:00.000Z',
+            version: 'v-old'
+          },
+          'idle-recent': {
+            arn: 'arn:idle-recent',
+            isUsedBy: null,
+            releasedOn: new Date().toISOString(),
+            version: 'v-recent'
+          },
+          'in-use': {
+            arn: 'arn:in-use',
+            isUsedBy: 'consumer-1',
+            releasedOn: '2019-01-01T00:00:00.000Z',
+            version: 'v-use'
+          }
+        }
+      }
+    });
+    await expect(
+      store.deregisterIdleEnhancedConsumers(kinesisClient, 1000)
+    ).resolves.toBeUndefined();
+    expect(update).toHaveBeenCalledTimes(1);
+    expect(update).toHaveBeenCalledWith({
+      ConditionExpression: '#a.#b.#c = :v AND #a.#b.#d = :w',
+      ExpressionAttributeNames: {
+        '#a': 'enhancedConsumers',
+        '#b': 'idle-old',
+        '#c': 'isUsedBy',
+        '#d': 'version'
+      },
+      ExpressionAttributeValues: { ':v': null, ':w': 'v-old' },
+      Key: { consumerGroup: 'test-group', streamName: 'test-stream' },
+      UpdateExpression: 'REMOVE #a.#b'
+    });
+    expect(kinesisClient.deregisterStreamConsumer).toHaveBeenCalledWith({
+      ConsumerARN: 'arn:idle-old'
+    });
+    expect(kinesisClient.deregisterStreamConsumer).toHaveBeenCalledTimes(1);
+  });
+
+  test('deregisterIdleEnhancedConsumers leaves a consumer alone if it was reassigned', async () => {
+    const store = new StateStore(options);
+    await store.start();
+    const { get, update } = new DynamoDbClient();
+    const kinesisClient = { deregisterStreamConsumer: vi.fn() };
+    get.mockResolvedValueOnce({
+      Item: {
+        enhancedConsumers: {
+          'idle-old': {
+            arn: 'arn:idle-old',
+            isUsedBy: null,
+            releasedOn: '2019-01-01T00:00:00.000Z',
+            version: 'v-old'
+          },
+          keep: {
+            arn: 'arn:keep',
+            isUsedBy: 'consumer-1',
+            releasedOn: '2019-01-01T00:00:00.000Z',
+            version: 'v-keep'
+          }
+        }
+      }
+    });
+    update.mockRejectedValueOnce(
+      Object.assign(new Error('nope'), { code: 'ConditionalCheckFailedException' })
+    );
+    await expect(
+      store.deregisterIdleEnhancedConsumers(kinesisClient, 1000)
+    ).resolves.toBeUndefined();
+    expect(kinesisClient.deregisterStreamConsumer).not.toHaveBeenCalled();
+  });
+
+  test('deregisterIdleEnhancedConsumers warns when AWS de-registration fails', async () => {
+    const store = new StateStore(options);
+    await store.start();
+    const { get } = new DynamoDbClient();
+    const kinesisClient = {
+      deregisterStreamConsumer: vi.fn(() => Promise.reject(new Error('aws boom')))
+    };
+    get.mockResolvedValueOnce({
+      Item: {
+        enhancedConsumers: {
+          'idle-old': {
+            arn: 'arn:idle-old',
+            isUsedBy: null,
+            releasedOn: '2019-01-01T00:00:00.000Z',
+            version: 'v-old'
+          },
+          keep: {
+            arn: 'arn:keep',
+            isUsedBy: 'consumer-1',
+            releasedOn: '2019-01-01T00:00:00.000Z',
+            version: 'v-keep'
+          }
+        }
+      }
+    });
+    await expect(
+      store.deregisterIdleEnhancedConsumers(kinesisClient, 1000)
+    ).resolves.toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(
+      'Could not deregister idle enhanced consumer "idle-old" from AWS:',
+      expect.objectContaining({ message: 'aws boom' })
+    );
+  });
+
+  test('deregisterIdleEnhancedConsumers always keeps at least one enhanced consumer', async () => {
+    const store = new StateStore(options);
+    await store.start();
+    const { get } = new DynamoDbClient();
+    const kinesisClient = { deregisterStreamConsumer: vi.fn(() => Promise.resolve()) };
+    get.mockResolvedValueOnce({
+      Item: {
+        enhancedConsumers: {
+          'idle-1': {
+            arn: 'arn:idle-1',
+            isUsedBy: null,
+            releasedOn: '2019-01-01T00:00:00.000Z',
+            version: 'v1'
+          },
+          'idle-2': {
+            arn: 'arn:idle-2',
+            isUsedBy: null,
+            releasedOn: '2019-01-01T00:00:00.000Z',
+            version: 'v2'
+          }
+        }
+      }
+    });
+    await expect(
+      store.deregisterIdleEnhancedConsumers(kinesisClient, 1000)
+    ).resolves.toBeUndefined();
+    expect(kinesisClient.deregisterStreamConsumer).toHaveBeenCalledTimes(1);
+  });
+
+  test('deregisterIdleEnhancedConsumers throws if removing from the state fails unexpectedly', async () => {
+    const store = new StateStore(options);
+    await store.start();
+    const { get, update } = new DynamoDbClient();
+    const kinesisClient = { deregisterStreamConsumer: vi.fn() };
+    get.mockResolvedValueOnce({
+      Item: {
+        enhancedConsumers: {
+          'idle-old': {
+            arn: 'arn:idle-old',
+            isUsedBy: null,
+            releasedOn: '2019-01-01T00:00:00.000Z',
+            version: 'v-old'
+          },
+          keep: {
+            arn: 'arn:keep',
+            isUsedBy: 'consumer-1',
+            releasedOn: '2019-01-01T00:00:00.000Z',
+            version: 'v-keep'
+          }
+        }
+      }
+    });
+    update.mockRejectedValueOnce(new Error('ddb boom'));
+    await expect(store.deregisterIdleEnhancedConsumers(kinesisClient, 1000)).rejects.toThrow(
+      'ddb boom'
+    );
+    expect(error).toHaveBeenCalledWith(expect.objectContaining({ message: 'ddb boom' }));
+    expect(kinesisClient.deregisterStreamConsumer).not.toHaveBeenCalled();
   });
 
   test('ensureShardStateExists makes a conditional update to insert the shard state', async () => {
@@ -1282,6 +1469,7 @@ describe('lib/state-store', () => {
           arn: 'arn:test-enhanced-consumer',
           isStandalone: false,
           isUsedBy: null,
+          releasedOn: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T/),
           version: '0001'
         }
       },
@@ -1311,6 +1499,7 @@ describe('lib/state-store', () => {
           arn: 'arn:test-enhanced-consumer',
           isStandalone: true,
           isUsedBy: null,
+          releasedOn: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T/),
           shards: {},
           version: '0001'
         }

--- a/templates/README.hbs
+++ b/templates/README.hbs
@@ -155,6 +155,10 @@ References:
 - [`SubscribeToShard` API reference](https://docs.aws.amazon.com/kinesis/latest/APIReference/API_SubscribeToShard.html), which also describes it as establishing an HTTP/2 connection.
 - [aws-sdk-cpp #3115](https://github.com/aws/aws-sdk-cpp/discussions/3115) and [#3118](https://github.com/aws/aws-sdk-cpp/issues/3118), where others observe `SubscribeToShard` going over HTTP/1.1 with batchy, high-latency delivery.
 
+### Deregistering idle enhanced consumers
+
+The client pre-registers up to `maxEnhancedConsumers` enhanced fan-out consumers, and AWS bills for each registered consumer whether or not it's reading. If your consumer group scales down, the extra consumers sit idle and keep costing money. Set `enhancedConsumerIdleTimeout` (in milliseconds) to have the client deregister consumers that have stayed unused for that long, keeping at least one. They get re-registered as the group scales back up, which takes a little while since AWS has to make each one active again, so pick a timeout comfortably larger than your lease and heartbeat cycles. It defaults to `0`, which leaves every registered consumer in place.
+
 ## State table (DynamoDB)
 
 The client stores its consumer state (shard leases and checkpoints) in a DynamoDB table, and it creates and manages that table for you. You don't have to create it ahead of time.


### PR DESCRIPTION
## Summary

AWS bills for every registered enhanced fan-out consumer whether or not it's reading. The client pre-registered up to `maxEnhancedConsumers` and **never** deregistered any from AWS (`deregisterStreamConsumer` existed but was never called), so a consumer group that scaled down left idle consumers running up charges — the problem in #517.

Adds an opt-in **`enhancedConsumerIdleTimeout`** option (milliseconds, default `0` = off). While `useEnhancedFanOut` is on, the heartbeat reconcile deregisters enhanced consumers that have stayed unused for at least the timeout, from both the stream state and AWS, always keeping at least one registered. They get re-registered as the group scales back up (which takes time as AWS makes each consumer `ACTIVE`), so the timeout should sit comfortably above the lease and heartbeat cycles.

## Mechanism

- The enhanced consumer state now carries a `releasedOn` timestamp, written at registration and whenever a usage is released (`clearOldConsumers`), so never-used excess consumers age out too — that's the actual scenario in the issue, not just released ones.
- New `StateStore#deregisterIdleEnhancedConsumers(kinesisClient, idleTimeout)`, wired into `HeartbeatManager`'s existing tick.
- **Race-safe:** the state removal is a conditional `REMOVE` guarded on the consumer still being unused (same `isUsedBy`/`version`); the AWS `deregisterStreamConsumer` only runs once that guard wins. So a consumer reassigned in the tiny window is left untouched, and a new owner that locks it makes the removal a no-op. An AWS-side failure is logged and self-heals (the next `setUpEnhancedConsumers` re-syncs state).

## Testing

- Unit: 451/451, 100% coverage. New state-store tests (idle past timeout, reassigned/guard miss, AWS failure warn, floor of one, unexpected DDB error) + heartbeat-manager tests (runs when enabled, skips otherwise) + an index plumbing test.
- **LocalStack, live:** a fan-out client with `maxEnhancedConsumers: 3, enhancedConsumerIdleTimeout: 3000` registered 3 consumers at start and dropped to **1** after the idle timeout + the next heartbeat tick (the in-use one kept), with the expected deregister log lines. Integration + smoke suites still pass.
- eslint clean.

Closes #517