### PR TITLE
feat: support consuming specific shards

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,20 @@ kinesis.on('data', async ({ records, setCheckpoint, continuePolling }) => {
 kinesis.startConsumer();
 ```
 
+### Reading specific shards
+
+By default the client reads from every shard, either by distributing them across the consumer group (`useAutoShardAssignment: true`) or by reading them all from a single client (`useAutoShardAssignment: false`). To read only a subset, pass `shardIds`:
+
+```js
+const kinesis = new Kinesis({
+  streamName: 'sample-stream',
+  shardIds: ['shardId-000000000000', 'shardId-000000000002']
+});
+kinesis.startConsumer();
+```
+
+With `shardIds` set, the client reads exactly those shards on its own and stays out of the group's automatic shard assignment, so `useAutoShardAssignment` doesn't apply. Shard IDs that aren't in the stream are logged and skipped.
+
 ### Inspecting shard assignments
 
 When several consumers share a group, the client spreads the stream's shards across them. `getShardAssignments()` reports who currently owns what, keyed by consumer ID, so you can see how the work is distributed without querying the DynamoDB state table yourself. The consumer has to be started first.
@@ -295,6 +309,7 @@ Initializes a new instance of the Kinesis client.
 | [options.s3.nonS3Keys] | <code>Array.&lt;string&gt;</code> | <code>[]</code> | If the `useS3ForLargeItems` option is set to        `true`, the `nonS3Keys` option lists the keys that will be sent normally on the kinesis record. |
 | [options.s3.tags] | <code>string</code> |  | If provided, the client will ensure that the        S3 bucket is tagged with these tags. If the bucket already has tags, they will be merged. |
 | [options.shardCount] | <code>number</code> | <code>1</code> | The number of shards that the newly-created stream        will use (if the `createStreamIfNeeded` option is set) |
+| [options.shardIds] | <code>Array.&lt;string&gt;</code> |  | When provided, the client consumes only these        specific shards instead of every shard in the stream. Setting this puts the client in        standalone mode (it reads the listed shards directly and does not take part in the        consumer group's automatic shard assignment, so `useAutoShardAssignment` is ignored).        Shard IDs that aren't found in the stream are logged and skipped. |
 | [options.shouldDeaggregate] | <code>string</code> \| <code>boolean</code> | <code>&quot;auto&quot;</code> | Whether the method retrieving the records             should expect aggregated records and deaggregate them appropriately. |
 | [options.shouldParseJson] | <code>string</code> \| <code>boolean</code> | <code>&quot;auto&quot;</code> | Whether if retrieved records' data should be parsed as JSON or not.        Set to "auto" to only attempt parsing if data looks like JSON. Set to true to force data parse. |
 | [options.statsInterval] | <code>number</code> | <code>30000</code> | The interval in milliseconds for how often to        emit the "stats" event. The event is only available while the consumer is running. |

--- a/lib/index.js
+++ b/lib/index.js
@@ -288,6 +288,11 @@ class Kinesis extends PassThrough {
    *        S3 bucket is tagged with these tags. If the bucket already has tags, they will be merged.
    * @param {number} [options.shardCount=1] - The number of shards that the newly-created stream
    *        will use (if the `createStreamIfNeeded` option is set)
+   * @param {Array<string>} [options.shardIds] - When provided, the client consumes only these
+   *        specific shards instead of every shard in the stream. Setting this puts the client in
+   *        standalone mode (it reads the listed shards directly and does not take part in the
+   *        consumer group's automatic shard assignment, so `useAutoShardAssignment` is ignored).
+   *        Shard IDs that aren't found in the stream are logged and skipped.
    * @param {string|boolean} [options.shouldDeaggregate=auto] - Whether the method retrieving the records
             should expect aggregated records and deaggregate them appropriately.
    * @param {string|boolean} [options.shouldParseJson=auto] - Whether if retrieved records' data should be parsed as JSON or not.
@@ -339,6 +344,7 @@ class Kinesis extends PassThrough {
       retryOptions,
       s3 = {},
       shardCount = 1,
+      shardIds,
       shouldDeaggregate = false,
       shouldParseJson = 'auto',
       statsInterval = 30000,
@@ -360,6 +366,8 @@ class Kinesis extends PassThrough {
       normLogger.error(errorMsg);
       throw new TypeError(errorMsg);
     }
+
+    const usesSpecificShards = Array.isArray(shardIds) && shardIds.length > 0;
 
     const s3BucketName = useS3ForLargeItems && (s3.bucketName || streamName);
     const recordsEncoder = useS3ForLargeItems
@@ -420,13 +428,14 @@ class Kinesis extends PassThrough {
       },
       s3Client: null,
       shardCount: boundedNumber(shardCount, { fallback: 1, min: 1 }),
+      shardIds: usesSpecificShards ? shardIds : undefined,
       shouldDeaggregate: Boolean(shouldDeaggregate),
       shouldParseJson,
       statsInterval: boundedNumber(statsInterval, { fallback: 30000, min: 1000 }),
       streamName,
       tags,
       useAutoCheckpoints: Boolean(useAutoCheckpoints),
-      useAutoShardAssignment: Boolean(useAutoShardAssignment),
+      useAutoShardAssignment: usesSpecificShards ? false : Boolean(useAutoShardAssignment),
       useEnhancedFanOut: Boolean(useEnhancedFanOut),
       usePausedPolling: Boolean(usePausedPolling),
       useS3ForLargeItems

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -639,6 +639,39 @@ describe('lib/index', () => {
     }
   });
 
+  test('providing shardIds makes the client read those shards in standalone mode', async () => {
+    const kinesis = new Kinesis({ ...options, shardIds: ['shardId-000000000001'] });
+    try {
+      await kinesis.startConsumer();
+      expect(StateStore).toHaveBeenCalledWith(
+        expect.objectContaining({
+          shardIds: ['shardId-000000000001'],
+          useAutoShardAssignment: false
+        })
+      );
+      expect(LeaseManager).toHaveBeenCalledWith(
+        expect.objectContaining({
+          shardIds: ['shardId-000000000001'],
+          useAutoShardAssignment: false
+        })
+      );
+    } finally {
+      kinesis.stopConsumer();
+    }
+  });
+
+  test('an empty shardIds array leaves automatic shard assignment in place', async () => {
+    const kinesis = new Kinesis({ ...options, shardIds: [] });
+    try {
+      await kinesis.startConsumer();
+      expect(LeaseManager).toHaveBeenCalledWith(
+        expect.objectContaining({ shardIds: undefined, useAutoShardAssignment: true })
+      );
+    } finally {
+      kinesis.stopConsumer();
+    }
+  });
+
   describe('listShards', () => {
     test('lists shards', async () => {
       const kinesis = new Kinesis(options);

--- a/lib/lease-manager.js
+++ b/lib/lease-manager.js
@@ -149,6 +149,8 @@ class LeaseManager {
    * @param {number} options.leaseAcquisitionRecoveryInterval - The interval in milliseconds for how often
    *        to re-attempt lease acquisitions when an error is returned.
    * @param {Object} options.logger - An instance of a logger.
+   * @param {Array<string>} [options.shardIds] - When provided, the manager only attempts to lease
+   *        these specific shards instead of every shard in the stream.
    * @param {Object} options.stateStore - An instance of the StateStore module.
    * @param {string} options.streamName - The name of the Kinesis stream.
    * @param {boolean} options.useAutoShardAssignment - Whether if the consumer is automatically
@@ -164,6 +166,7 @@ class LeaseManager {
       leaseAcquisitionInterval,
       leaseAcquisitionRecoveryInterval,
       logger,
+      shardIds,
       stateStore,
       streamName,
       useAutoShardAssignment,
@@ -178,6 +181,7 @@ class LeaseManager {
       leaseAcquisitionInterval,
       leaseAcquisitionRecoveryInterval,
       logger,
+      shardIds,
       stateStore,
       streamName,
       useEnhancedFanOut
@@ -197,6 +201,7 @@ class LeaseManager {
       leaseAcquisitionInterval = ACQUIRE_LEASES_INTERVAL,
       leaseAcquisitionRecoveryInterval = ACQUIRE_LEASES_RECOVERY_INTERVAL,
       logger,
+      shardIds,
       stateStore,
       timeoutId,
       useEnhancedFanOut
@@ -227,7 +232,17 @@ class LeaseManager {
           }
         }
 
-        const shards = await getStreamShards(privateProps);
+        const streamShards = await getStreamShards(privateProps);
+        let shards = streamShards;
+        if (shardIds) {
+          const missing = shardIds.filter((id) => !streamShards[id]);
+          if (missing.length > 0) {
+            logger.warn(`Ignoring requested shards not found in the stream: ${missing.join(', ')}`);
+          }
+          shards = Object.fromEntries(
+            Object.entries(streamShards).filter(([id]) => shardIds.includes(id))
+          );
+        }
 
         const changesDetected = (
           await Object.keys(shards).reduce(async (result, id) => {

--- a/lib/lease-manager.test.js
+++ b/lib/lease-manager.test.js
@@ -19,7 +19,8 @@ describe('lib/lease-manager', () => {
 
   const debug = vi.fn();
   const error = vi.fn();
-  const logger = { debug, error };
+  const warn = vi.fn();
+  const logger = { debug, error, warn };
 
   const getAssignedEnhancedConsumer = vi.fn();
   const getShardAndStreamState = vi.fn();
@@ -53,6 +54,7 @@ describe('lib/lease-manager', () => {
     releaseShardLease.mockClear();
     setTimeout.mockClear();
     stop.mockClear();
+    warn.mockClear();
   });
 
   test('the module exports the expected', () => {
@@ -315,6 +317,52 @@ describe('lib/lease-manager', () => {
     expect(debug).toHaveBeenNthCalledWith(1, 'Attempting lease acquisition…');
     expect(debug).toHaveBeenNthCalledWith(2, 'Lease for "shardId-0001" acquired.');
     expect(debug).toHaveBeenCalledTimes(2);
+    manager.stop();
+  });
+
+  test('with shardIds the manager only leases the requested shards present in the stream', async () => {
+    getStreamShards.mockResolvedValueOnce({
+      'shardId-0000': {},
+      'shardId-0001': {},
+      'shardId-0002': {}
+    });
+    const fiveMinsFromNow = new Date(Date.now() + 1000 * 60 * 5);
+    getShardAndStreamState.mockResolvedValueOnce({
+      shardState: { leaseExpiration: fiveMinsFromNow.toISOString(), version: 1 },
+      streamState: { consumers: {}, shards: {} }
+    });
+    const manager = new LeaseManager({
+      ...options,
+      shardIds: ['shardId-0001', 'shardId-9999'],
+      useAutoShardAssignment: false
+    });
+    await manager.start();
+    expect(getShardAndStreamState).toHaveBeenCalledTimes(1);
+    expect(getShardAndStreamState).toHaveBeenCalledWith('shardId-0001', {});
+    expect(lockShardLease).toHaveBeenCalledWith('shardId-0001', 300000, 1, expect.any(Object));
+    expect(error).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(
+      'Ignoring requested shards not found in the stream: shardId-9999'
+    );
+    manager.stop();
+  });
+
+  test('with shardIds all present the manager leases them without warnings', async () => {
+    getStreamShards.mockResolvedValueOnce({ 'shardId-0000': {}, 'shardId-0001': {} });
+    const fiveMinsFromNow = new Date(Date.now() + 1000 * 60 * 5);
+    getShardAndStreamState.mockResolvedValueOnce({
+      shardState: { leaseExpiration: fiveMinsFromNow.toISOString(), version: 1 },
+      streamState: { consumers: {}, shards: {} }
+    });
+    const manager = new LeaseManager({
+      ...options,
+      shardIds: ['shardId-0000'],
+      useAutoShardAssignment: false
+    });
+    await manager.start();
+    expect(getShardAndStreamState).toHaveBeenCalledTimes(1);
+    expect(getShardAndStreamState).toHaveBeenCalledWith('shardId-0000', {});
+    expect(warn).not.toHaveBeenCalled();
     manager.stop();
   });
 

--- a/templates/README.hbs
+++ b/templates/README.hbs
@@ -117,6 +117,20 @@ kinesis.on('data', async ({ records, setCheckpoint, continuePolling }) => {
 kinesis.startConsumer();
 ```
 
+### Reading specific shards
+
+By default the client reads from every shard, either by distributing them across the consumer group (`useAutoShardAssignment: true`) or by reading them all from a single client (`useAutoShardAssignment: false`). To read only a subset, pass `shardIds`:
+
+```js
+const kinesis = new Kinesis({
+  streamName: 'sample-stream',
+  shardIds: ['shardId-000000000000', 'shardId-000000000002']
+});
+kinesis.startConsumer();
+```
+
+With `shardIds` set, the client reads exactly those shards on its own and stays out of the group's automatic shard assignment, so `useAutoShardAssignment` doesn't apply. Shard IDs that aren't in the stream are logged and skipped.
+
 ### Inspecting shard assignments
 
 When several consumers share a group, the client spreads the stream's shards across them. `getShardAssignments()` reports who currently owns what, keyed by consumer ID, so you can see how the work is distributed without querying the DynamoDB state table yourself. The consumer has to be started first.


### PR DESCRIPTION
## Summary

Adds a **`shardIds`** option that restricts the client to a subset of the stream's shards instead of consuming every shard — the request in #536.

The library already had two modes: distribute shards across the consumer group (`useAutoShardAssignment: true`) or read them all from one client (`useAutoShardAssignment: false`). `shardIds` is the natural "read only *these* shards" extension: the lease manager now only attempts to lease the requested shards, warning about and skipping any IDs not present in the stream.

Per the chosen design, **`shardIds` implies standalone mode**: the client reads the listed shards directly and stays out of the group's automatic shard assignment, so `useAutoShardAssignment` is forced off when `shardIds` is set. An empty or absent `shardIds` leaves existing behavior unchanged.

## Testing

- Unit: 447/447, 100% coverage. New lease-manager tests (only requested shards get leased; unknown IDs warned + skipped; all-present case logs nothing) + index tests (shardIds forces standalone and flows to the state store / lease manager; empty array is a no-op).
- **LocalStack, live:** a 3-shard stream consumed with `shardIds: [shard-0, <unknown>]` delivered 17 records, **all from shard-0 only** (the unknown ID ignored). Integration + smoke suites still pass.
- eslint clean.

## Docs

README "Reading specific shards" section + the auto-generated option entry.

Closes #536