### PR TITLE
ci: add a Cut Release action and document the release flow

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -1,0 +1,92 @@
+name: Cut Release
+on:
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: 'Semver bump to apply'
+        required: true
+        default: 'minor'
+        type: choice
+        options:
+          - major
+          - minor
+          - patch
+      custom_version:
+        description: 'Explicit version (overrides the bump, e.g. 2.0.0 or 2.0.0-rc.1)'
+        required: false
+        type: string
+jobs:
+  cut:
+    name: Cut release branch and open PR to main
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v6
+        with:
+          ref: develop
+          fetch-depth: 0
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          check-latest: true
+          node-version: '22'
+      - name: Install
+        run: npm ci --ignore-scripts --loglevel=error
+        env:
+          DISABLE_OPENCOLLECTIVE: true
+      - name: Run linter
+        run: npm run eslint
+      - name: Run tests
+        run: npm test
+        env:
+          CI: true
+      - name: Bump version and regenerate changelog
+        run: |
+          bump="${{ github.event.inputs.custom_version }}"
+          if [ -z "$bump" ]; then
+            bump="${{ github.event.inputs.release_type }}"
+          fi
+          npm version "$bump" --no-git-tag-version
+          version="$(node -p "require('./package.json').version")"
+          echo "version=$version" >> "$GITHUB_ENV"
+      - name: Guard against an existing release branch
+        run: |
+          if git ls-remote --exit-code --heads origin "release/${version}" > /dev/null 2>&1; then
+            echo "::error::release/${version} already exists on the remote. Delete it or pick a different version."
+            exit 1
+          fi
+      - name: Create release branch and commit
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "release/${version}"
+          git add package.json package-lock.json CHANGELOG.md
+          git commit -m "${version}"
+          git push origin "release/${version}"
+      - name: Open pull request into main
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          cat > /tmp/pr-body.md <<'BODY'
+          Cut by the **Cut Release** action from `develop`. Bumps the version, regenerates `CHANGELOG.md`, and opens this PR so the release stays a human merge.
+
+          ## Before merging
+          - [ ] Review `CHANGELOG.md` and hand-label any breaking changes (auto-changelog goes off commit subjects and will not flag them).
+          - [ ] Confirm the version and the diff are what you expect.
+
+          ## On merge to `main`
+          The existing pipeline takes over automatically:
+          - `publish-module.yml` re-runs lint + tests, publishes to npm (OIDC/provenance, skips if already published), then tags and creates the GitHub Release.
+          - `backmerge.yml` opens the `main` → `develop` sync PR.
+
+          ## Note on checks
+          This PR was opened by the Actions token, so GitHub will not auto-run the matrix on it (the recursion-prevention rule). The release branch was linted and tested at cut time, and the publish workflow re-validates before publishing. Admin-merge, or push an empty commit to the branch to trigger the checks.
+          BODY
+          gh pr create \
+            --base main \
+            --head "release/${version}" \
+            --title "Release v${version}" \
+            --body-file /tmp/pr-body.md

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,58 @@
+# Releasing
+
+This is how a release goes out. Cutting one comes down to a single button in the Actions tab. The only manual gate is the merge into `main`; once that lands, the rest of the pipeline (publish, tag, GitHub release, back-merge) runs on its own.
+
+## The pipeline
+
+1. **Cut Release** (`.github/workflows/release-cut.yml`, manual). Bumps the version on `develop`, regenerates `CHANGELOG.md`, pushes a `release/X.Y.Z` branch, and opens a PR into `main`.
+2. **You review and merge that PR into `main`.** This is the gate. Nothing publishes until you merge.
+3. **Publish Module** (`.github/workflows/publish-module.yml`, on push to `main`). Re-runs lint and tests, publishes to npm with provenance over OIDC (skips if the version is already published), then tags `vX.Y.Z` and creates the GitHub Release with generated notes.
+4. **Back-merge** (`.github/workflows/backmerge.yml`, on push to `main`). Opens a `main` → `develop` PR so the version bump and changelog flow back.
+
+## Cutting a release
+
+1. Go to **Actions → Cut Release → Run workflow**.
+2. Pick the **bump** (`major`, `minor`, or `patch`), or fill in **custom_version** for an explicit value like `2.0.0` or `2.0.0-rc.1`. The custom value wins if both are set.
+3. Run it. The action checks out `develop`, lints and tests it, runs `npm version <bump> --no-git-tag-version` (which regenerates `CHANGELOG.md` via the `version` npm script), commits as `X.Y.Z`, pushes `release/X.Y.Z`, and opens the PR.
+
+It always cuts from `develop`, whatever ref you launch it from.
+
+## Reviewing the release PR
+
+- Read `CHANGELOG.md`. auto-changelog builds it from commit subjects, so it will not mark breaking changes. Hand-edit the entry to call those out (for the 2.0.0 line, the #332 polling read-error change is breaking: fatal read errors now warn and self-heal instead of surfacing as a stream `'error'` event).
+- Confirm the version and the diff look right.
+
+## Merging to `main`
+
+The PR is opened by the Actions token, so GitHub suppresses workflow runs on it (the recursion-prevention rule), which means the required checks will not post on their own. The branch was already linted and tested at cut time, and Publish Module re-validates before it publishes. So either admin-merge, or push an empty commit to the release branch to trigger the matrix first:
+
+```bash
+git commit --allow-empty -m "ci: trigger checks" && git push
+```
+
+Merge with a regular merge commit. Once it lands on `main`, publish, tag, release, and the back-merge PR all fire on their own.
+
+## After the release
+
+- Merge the back-merge PR (`main` → `develop`) once it is green. It is opened by the token too, so admin-merge applies.
+- Leave `support/1.x` alone for a main-line release. It tracks v1 and must not be fast-forwarded to `main` once v2 has shipped.
+- Post any "fix is out" notes on the issues the release closed.
+
+## v1 maintenance releases
+
+Patches to the v1 line come off `support/1.x`, not through this action. Bump there, then run **Publish Module** by hand (**Actions → Publish Module → Run workflow**) with `dist_tag` set to `v1` so the publish does not move npm's `latest`.
+
+## Manual fallback
+
+If you need to cut by hand (the action is down, or you want signed commits), the equivalent is:
+
+```bash
+git checkout develop && git pull
+npm version <major|minor|patch> --no-git-tag-version   # bumps + regenerates CHANGELOG
+git checkout -b release/$(node -p "require('./package.json').version")
+git commit -am "$(node -p "require('./package.json').version")"
+git push -u origin HEAD
+gh pr create --base main --title "Release v$(node -p "require('./package.json').version")"
+```
+
+Then review, merge into `main`, and let the pipeline take it from there.


### PR DESCRIPTION
Adds the missing front half of the release pipeline: a **Cut Release** action and a `RELEASING.md` that documents the whole flow. We already automate everything after a bump lands on `main` (publish, tag, GitHub release, back-merge); the cut itself was hand-run, which is where the process can drift.

## What's here

- **`.github/workflows/release-cut.yml`** — a manual `workflow_dispatch` you run from the Actions tab. Inputs: a `release_type` (major/minor/patch) or an explicit `custom_version`. It checks out `develop`, lints and tests it, runs `npm version <bump> --no-git-tag-version` (which regenerates `CHANGELOG.md` via the existing `version` npm script), commits as `X.Y.Z`, pushes `release/X.Y.Z`, and opens a PR into `main`.
- **`RELEASING.md`** — documents the pipeline end to end, the cut steps, what to review on the release PR, the merge gate, v1 maintenance releases off `support/1.x`, and a manual fallback.

## Design

The action stops at "PR open against `main`." Merging that PR stays a human decision, so the irreversible npm publish + main merge gate is unchanged. Once it merges, `publish-module.yml` and `backmerge.yml` take over as they do today.

## Caveats (also in `RELEASING.md`)

- The release PR is opened by the Actions token, so GitHub suppresses workflow runs on it (recursion prevention). The branch is linted and tested at cut time, and `publish-module.yml` re-validates before publishing. Admin-merge, or push an empty commit to trigger the matrix.
- The `X.Y.Z` commit is created in CI and is unsigned (same as the existing CI-created tag). The manual fallback in `RELEASING.md` covers cutting locally if a signed commit is wanted.

## Validation

- `npm run eslint` clean; workflow YAML parses; `npm pack --dry-run` unchanged (24 files, neither new file ships).
