### PR TITLE
ci: back-merge main into develop directly via a GitHub App

### DIFF
--- a/.github/workflows/backmerge.yml
+++ b/.github/workflows/backmerge.yml
@@ -4,19 +4,47 @@ on:
     branches:
       - main
 jobs:
-  open-back-merge:
-    name: Open back-merge PR
+  back-merge:
+    name: Back-merge main into develop
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
     steps:
-      - name: Clone repository
-        uses: actions/checkout@v6
-      - name: Open back-merge PR
+      - name: Mint App token (if configured)
+        id: app-token
+        if: ${{ vars.BACKMERGE_APP_ID != '' }}
+        continue-on-error: true
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.BACKMERGE_APP_ID }}
+          private-key: ${{ secrets.BACKMERGE_APP_KEY }}
+      - name: Back-merge main into develop
         env:
-          GH_TOKEN: ${{ github.token }}
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
+          FALLBACK_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
         run: |
+          set -euo pipefail
+
+          # Happy path: a configured GitHub App merges main into develop directly
+          # via the server-side Merges API (GitHub-signed commit), bypassing
+          # develop's protection. No PR, no human step.
+          if [ -n "${APP_TOKEN:-}" ]; then
+            echo "App token present; attempting a direct server-side merge."
+            if GH_TOKEN="$APP_TOKEN" gh api -X POST "repos/$REPO/merges" \
+                 -f base=develop -f head=main > /tmp/merge.json 2> /tmp/merge.err; then
+              echo "Back-merged main into develop (or develop was already up to date)."
+              exit 0
+            fi
+            echo "Direct merge was rejected; falling back to a pull request."
+            cat /tmp/merge.err || true
+          else
+            echo "No App token configured; opening a back-merge pull request."
+          fi
+
+          # Fallback: open (or reuse) a main -> develop PR with the default token.
+          export GH_TOKEN="$FALLBACK_TOKEN"
           if [ -n "$(gh pr list --base develop --head main --state open --json number --jq '.[0].number // empty')" ]; then
             echo "A back-merge PR is already open."
             exit 0

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -7,7 +7,7 @@ This is how a release goes out. Cutting one comes down to a single button in the
 1. **Cut Release** (`.github/workflows/release-cut.yml`, manual). Bumps the version on `develop`, regenerates `CHANGELOG.md`, pushes a `release/X.Y.Z` branch, and opens a PR into `main`.
 2. **You review and merge that PR into `main`.** This is the gate. Nothing publishes until you merge.
 3. **Publish Module** (`.github/workflows/publish-module.yml`, on push to `main`). Re-runs lint and tests, publishes to npm with provenance over OIDC (skips if the version is already published), then tags `vX.Y.Z` and creates the GitHub Release with generated notes.
-4. **Back-merge** (`.github/workflows/backmerge.yml`, on push to `main`). Opens a `main` → `develop` PR so the version bump and changelog flow back.
+4. **Back-merge** (`.github/workflows/backmerge.yml`, on push to `main`). Syncs the version bump and changelog back to `develop`. With the back-merge App configured (see below) it merges `main` into `develop` directly, no PR. Without it, or if the merge is blocked, it opens a `main` → `develop` PR to admin-merge.
 
 ## Cutting a release
 
@@ -34,9 +34,26 @@ Merge with a regular merge commit. Once it lands on `main`, publish, tag, releas
 
 ## After the release
 
-- Merge the back-merge PR (`main` → `develop`) once it is green. It is opened by the token too, so admin-merge applies.
+- The `main` → `develop` back-merge runs on its own. With the App configured it merges directly and there is nothing to do. If it fell back to a PR (no App, or the merge was blocked), admin-merge that PR once you see it.
 - Leave `support/1.x` alone for a main-line release. It tracks v1 and must not be fast-forwarded to `main` once v2 has shipped.
 - Post any "fix is out" notes on the issues the release closed.
+
+## Back-merge automation (GitHub App)
+
+The default `GITHUB_TOKEN` cannot write to protected `develop` (it can neither trigger the required checks nor bypass protection), so without help the back-merge can only open a PR that you then admin-merge. A GitHub App removes that manual step: `backmerge.yml` mints a short-lived token from the App and merges `main` into `develop` server-side.
+
+It is opt-in. Until the two settings below exist, the workflow just opens the PR as before, so it is safe to run without the App.
+
+One-time setup:
+
+1. **Create the App** (org-owned is best, so it outlives any one person): **lifion org → Settings → Developer settings → GitHub Apps → New GitHub App**. No webhook. Repository permissions: **Contents: Read and write**, **Pull requests: Read and write**, and **Administration: Read and write** (the last is what lets it clear `develop`'s required status checks, since classic protection only yields to admins).
+2. **Generate a private key** for the App and download the `.pem`.
+3. **Install** the App on `lifion-kinesis` only.
+4. In the repo, add a **variable** `BACKMERGE_APP_ID` (the App's numeric ID) and a **secret** `BACKMERGE_APP_KEY` (the full contents of the `.pem`).
+
+The first back-merge after setup confirms the direct path; if anything is off it falls back to a PR, so nothing gets stuck. The merge commit is created by the Merges API, so it is GitHub-signed (verified), which satisfies the signed-commits rule on `develop`.
+
+Note the trade-off: the App's private key is a long-lived stored credential with admin scope on this repo. Keep it org-owned, scoped to this one repo, and rotate the key if it is ever exposed.
 
 ## v1 maintenance releases
 


### PR DESCRIPTION
Removes the manual admin-merge on the `main` → `develop` back-merge after each release.

## Problem
The default `GITHUB_TOKEN` can't write to protected `develop` — it neither triggers the required checks nor bypasses protection — so `backmerge.yml` could only open a PR that then sat on "expected" checks and needed an admin-merge every release (e.g. #792).

## Change
`backmerge.yml` now mints a short-lived token from an optional **GitHub App** and merges `main` into `develop` server-side via the Merges API. Because the merge commit is created server-side it's GitHub-signed (verified), which satisfies `develop`'s signed-commits rule.

## Safe and opt-in
- Until the `BACKMERGE_APP_ID` variable and `BACKMERGE_APP_KEY` secret exist, the App step is skipped and it opens the PR exactly as before.
- If the direct merge is ever rejected, it falls back to opening the PR.

So this can't get stuck, and it degrades to today's behavior with no App configured.

## Follow-up (out of band)
Create the App (Contents + Pull requests + Administration: RW), install it on this repo only, and add the two settings. `RELEASING.md` documents the full setup and the trade-off (the App's key is a long-lived admin-scoped credential).

## Validation
- `npm run eslint` clean; `backmerge.yml` YAML parses; `RELEASING.md` prose checked (no em/en dashes).
